### PR TITLE
docs: clarify allowed frontend origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ VITE_SUPABASE_PUBLISHABLE_KEY="public-anon-key"
 VITE_DEFAULT_ORG="assistjur"
 
 # 🌐 Domínios permitidos para as Edge Functions (separados por vírgula)
-SITE_URL="http://localhost:5173,https://app.exemplo.com"
+SITE_URL="http://localhost:5173,https://preview--assitjur.lovable.app,https://<seu-dominio-prod>.com"
 
 # 🤖 OpenAI (usado nas Edge Functions e Playground)
 # 👉 Nunca use a chave real aqui — só documente
@@ -30,4 +30,4 @@ SMTP_PASS=""
 
 # 🛡️ CORS
 # Domínios permitidos separados por vírgula
-ALLOWED_ORIGINS="https://assistjur.ia"
+ALLOWED_ORIGINS="http://localhost:5173,https://preview--assitjur.lovable.app,https://<seu-dominio-prod>.com"


### PR DESCRIPTION
## Summary
- document multiple frontend domains for CORS in .env example
- ensure CORS helper already allows required headers

## Testing
- `npm run lint` (fails: Cannot find package '@eslint/js' imported from eslint.config.js)
- `npm run test:integration` (fails: sh: 1: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68bec72451e88322ac1072194644f854