### PR TITLE
feat: normalize payloads for witness and process endpoints

### DIFF
--- a/supabase/functions/assistjur-processos/index.ts
+++ b/supabase/functions/assistjur-processos/index.ts
@@ -47,6 +47,17 @@ serve(async (req) => {
     );
   }
 
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return new Response(
+      JSON.stringify({
+        error: 'invalid_payload',
+        hint: 'JSON object esperado',
+        example: { filters: {}, page: 1, limit: 50 }
+      }),
+      { status: 400, headers }
+    );
+  }
+
   const filters = body?.filters ?? {};
 
   let page = Number(body?.page ?? 1);

--- a/supabase/functions/mapa-testemunhas-testemunhas/index.ts
+++ b/supabase/functions/mapa-testemunhas-testemunhas/index.ts
@@ -71,7 +71,11 @@ serve(async (req) => {
 
     if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
       return new Response(
-        JSON.stringify({ error: 'invalid_payload', hint: 'JSON object esperado' }),
+        JSON.stringify({
+          error: 'invalid_payload',
+          hint: 'JSON object esperado',
+          example: { page: 1, limit: 20 }
+        }),
         { status: 400, headers }
       );
     }


### PR DESCRIPTION
## Summary
- include sample payload in invalid JSON object errors for witness map function
- validate request body shape in process endpoint and return consistent sample payload

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:integration` *(fails: vitest: not found)*
- `npm install --no-save @eslint/js@^9.32.0 vitest@^3.2.4` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bec713ec188322905846ed1d6ca7d0