### PR TITLE
feat: add correlation id for edge calls

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,5 +1,5 @@
 // CORS with domain restriction for security
-export function corsHeaders(req: Request): Record<string, string> {
+export function corsHeaders(req: Request, cid?: string): Record<string, string> {
   const origin = req.headers.get("Origin") || "";
   let hostname = "";
   try {
@@ -44,7 +44,7 @@ export function corsHeaders(req: Request): Record<string, string> {
     allowOrigin = origin;
   }
 
-  console.log(`CORS: Origin ${origin} -> Allow: ${allowOrigin}`);
+  console.log(`${cid ? `[cid=${cid}] ` : ''}CORS: Origin ${origin} -> Allow: ${allowOrigin}`);
   
   return {
     "Access-Control-Allow-Origin": allowOrigin,
@@ -55,9 +55,9 @@ export function corsHeaders(req: Request): Record<string, string> {
   };
 }
 
-export function handlePreflight(req: Request) {
+export function handlePreflight(req: Request, cid?: string) {
   if (req.method === "OPTIONS") {
-    const headers = corsHeaders(req);
+    const headers = corsHeaders(req, cid);
     headers["Access-Control-Allow-Methods"] =
       headers["Access-Control-Allow-Methods"] || "POST, OPTIONS, GET";
     return new Response("ok", { headers });

--- a/supabase/functions/mapa-testemunhas-processos/index.ts
+++ b/supabase/functions/mapa-testemunhas-processos/index.ts
@@ -1,20 +1,21 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { normalizeMapaRequest, MapaResponseSchema } from "../../../src/contracts/mapaTestemunhas.ts";
 
-function json(body: unknown, status = 200) {
+function json(cid: string, body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", "x-correlation-id": cid },
   });
 }
 
 serve(async (req: Request) => {
+  const cid = req.headers.get('x-correlation-id') ?? crypto.randomUUID();
   try {
     let payload: unknown;
     try {
       payload = await req.json();
     } catch {
-      return json({ error: "Body deve ser JSON (Content-Type: application/json)" }, 400);
+      return json(cid, { error: "Body deve ser JSON (Content-Type: application/json)" }, 400);
     }
 
     let dto: ReturnType<typeof normalizeMapaRequest>;
@@ -22,8 +23,8 @@ serve(async (req: Request) => {
       dto = normalizeMapaRequest(payload);
     } catch (e) {
       const issues = (e as any)?.issues ?? e;
-      console.error("Validação falhou:", issues);
-      return json({ error: "Validação falhou", issues }, 400);
+      console.error(`[cid=${cid}] Validação falhou:`, issues);
+      return json(cid, { error: "Validação falhou", issues }, 400);
     }
 
     // TODO: query real no banco com dto.filtros/pagina/limite
@@ -32,13 +33,13 @@ serve(async (req: Request) => {
     // opcional: validar resposta
     const ok = MapaResponseSchema.safeParse(result);
     if (!ok.success) {
-      console.error("Resposta inválida:", ok.error.issues);
-      return json({ error: "Resposta inválida do servidor" }, 500);
+      console.error(`[cid=${cid}] Resposta inválida:`, ok.error.issues);
+      return json(cid, { error: "Resposta inválida do servidor" }, 500);
     }
 
-    return json(result);
+    return json(cid, result);
   } catch (err) {
-    console.error("Erro inesperado:", err);
-    return json({ error: "Erro interno" }, 500);
+    console.error(`[cid=${cid}] Erro inesperado:`, err);
+    return json(cid, { error: "Erro interno" }, 500);
   }
 });


### PR DESCRIPTION
## Summary
- generate x-correlation-id on frontend edge requests and log it on errors
- propagate correlation id through Edge Function logs and responses

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bed57c1a0c8322a8c6ac1256f12269