### PR TITLE
chore: normalize mapa testemunhas limits

### DIFF
--- a/src/contracts/mapaTestemunhas.ts
+++ b/src/contracts/mapaTestemunhas.ts
@@ -15,7 +15,12 @@ const filtersSchema = z
 export const mapaTestemunhasSchema = z.object({
   filters: filtersSchema,
   page: z.coerce.number().int().min(1).default(1),
-  limit: z.coerce.number().int().min(1).max(200).default(20),
+  limit: z
+    .coerce.number()
+    .int()
+    .min(1)
+    .default(20)
+    .transform((n) => (n > 200 ? 200 : n)),
   sortBy: z.string().trim().optional(),
   sortDir: z.enum(["asc", "desc"]).optional(),
 });

--- a/tests/mapa-testemunhas-endpoints.test.ts
+++ b/tests/mapa-testemunhas-endpoints.test.ts
@@ -4,14 +4,12 @@
 
 import { describe, it, expect } from 'vitest'
 import { normalizeMapaRequest as backendNormalize } from '../src/contracts/mapaTestemunhas'
-import frontendNormalize from '../src/lib/normalizeMapaRequest'
 
 type EndpointResponse = { status: number; body?: unknown }
 
-function processosEndpoint(payload: unknown, useClient = true): EndpointResponse {
+function processosEndpoint(payload: unknown): EndpointResponse {
   try {
-    const normalized = useClient ? frontendNormalize(payload) : payload
-    const result = backendNormalize(normalized)
+    const result = backendNormalize(payload)
     return { status: 200, body: result }
   } catch {
     return { status: 400 }
@@ -19,8 +17,8 @@ function processosEndpoint(payload: unknown, useClient = true): EndpointResponse
 }
 
 describe('mapa-testemunhas-processos endpoint', () => {
-  it('rejects invalid payload without client normalization', () => {
-    const res = processosEndpoint({ filters: 'invalido', page: 0, limit: 500 }, false)
+  it('rejects invalid payload', () => {
+    const res = processosEndpoint({ filters: 'invalido', page: 0 })
     expect(res.status).toBe(400)
   })
 
@@ -31,9 +29,15 @@ describe('mapa-testemunhas-processos endpoint', () => {
   })
 
   it('coerces page and limit from strings', () => {
-    const res = processosEndpoint({ page: '2', limit: '40' })
+    const res = processosEndpoint({ page: '2', limit: '50' })
     expect(res.status).toBe(200)
-    expect(res.body).toMatchObject({ page: 2, limit: 40 })
+    expect(res.body).toMatchObject({ page: 2, limit: 50 })
+  })
+
+  it('clamps limit to 200 when above maximum', () => {
+    const res = processosEndpoint({ limit: '999' })
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({ page: 1, limit: 200, filters: {} })
   })
 
   it('handles empty payload using defaults', () => {


### PR DESCRIPTION
## Summary
- clamp `limit` to 200 while normalizing mapa testemunhas requests
- simplify tests to rely on backend normalization and cover default/coercion cases

## Testing
- `npm test tests/mapa-testemunhas-endpoints.test.ts` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bed55222848322b690786d7c923da2