### PR TITLE
refine shared CORS helper

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -14,14 +14,11 @@ export function buildCorsHeaders(req: Request) {
   const headers: Record<string,string> = {
     'Vary': 'Origin',
     'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
-    'Access-Control-Allow-Headers': 'authorization,apikey,content-type,x-client-info,x-correlation-id,prefer,range',
-    'Access-Control-Max-Age': '86400',
+    'Access-Control-Allow-Headers': 'authorization,apikey,content-type,x-correlation-id,x-client-info',
   }
   if (raw.length > 0) {
     if (origin && originIsAllowed(origin, patterns)) {
       headers['Access-Control-Allow-Origin'] = origin
-    } else {
-      headers['Access-Control-Allow-Origin'] = '*' // fallback dev
     }
   } else {
     headers['Access-Control-Allow-Origin'] = '*'


### PR DESCRIPTION
## Summary
- refine CORS helper to read ALLOWED_ORIGINS and standard headers

## Testing
- `deno fmt supabase/functions/_shared/cors.ts` *(fails: command not found)*
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bffff931448322a3d9d56bddd25a2a