### PR TITLE
Add correlation IDs to mapa-testemunhas errors

### DIFF
--- a/src/lib/store/mapa-testemunhas.ts
+++ b/src/lib/store/mapa-testemunhas.ts
@@ -40,6 +40,7 @@ type TabType = 'processos' | 'testemunhas';
 interface ErrorState {
   hasError: boolean;
   message?: string;
+  errorCid?: string;
 }
 
 interface MapaTestemunhasStore {
@@ -57,6 +58,7 @@ interface MapaTestemunhasStore {
   isPiiMasked: boolean;
   hasError: boolean;
   errorMessage: string;
+  errorCid?: string;
   lastUpdate: Date | null;
   
   // Filters
@@ -92,7 +94,7 @@ interface MapaTestemunhasStore {
   setIsImportModalOpen: (open: boolean) => void;
   setIsLoading: (loading: boolean) => void;
   setIsPiiMasked: (masked: boolean) => void;
-  setError: (error: boolean, message?: string) => void;
+  setError: (error: boolean, message?: string, cid?: string) => void;
   setLastUpdate: (date: Date | null) => void;
   setProcessoFilters: (filters: Partial<FilterProcesso>) => void;
   setTestemunhaFilters: (filters: Partial<FilterTestemunha>) => void;
@@ -137,6 +139,7 @@ export const useMapaTestemunhasStore = create<MapaTestemunhasStore>((set, get) =
   isPiiMasked: false,
   hasError: false,
   errorMessage: '',
+  errorCid: undefined,
   lastUpdate: null,
   processoFilters: {},
   testemunhaFilters: {},
@@ -166,7 +169,7 @@ export const useMapaTestemunhasStore = create<MapaTestemunhasStore>((set, get) =
   setIsImportModalOpen: (open) => set({ isImportModalOpen: open }),
   setIsLoading: (loading) => set({ isLoading: loading }),
   setIsPiiMasked: (masked) => set({ isPiiMasked: masked }),
-  setError: (error, message = '') => set({ hasError: error, errorMessage: message }),
+  setError: (error, message = '', cid) => set({ hasError: error, errorMessage: message, errorCid: cid }),
   setLastUpdate: (date) => set({ lastUpdate: date }),
   setProcessoFilters: (filters) => 
     set((state) => ({ 
@@ -236,6 +239,7 @@ export const selectIsLoading = (state: MapaTestemunhasStore) => state.isLoading;
 export const selectIsPiiMasked = (state: MapaTestemunhasStore) => state.isPiiMasked;
 export const selectHasError = (state: MapaTestemunhasStore) => state.hasError;
 export const selectErrorMessage = (state: MapaTestemunhasStore) => state.errorMessage;
+export const selectErrorCid = (state: MapaTestemunhasStore) => state.errorCid;
 export const selectLastUpdate = (state: MapaTestemunhasStore) => state.lastUpdate;
 export const selectProcessoFilters = (state: MapaTestemunhasStore) => state.processoFilters;
 export const selectTestemunhaFilters = (state: MapaTestemunhasStore) => state.testemunhaFilters;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -225,7 +225,7 @@ const mapaRequestSchema = z.object({
 // Fetch functions with Supabase fallback to mocks
 export const fetchPorProcesso = async (
   params: MapaTestemunhasRequest<ProcessoFilters>
-): Promise<{ data: PorProcesso[]; total: number; error?: string }> => {
+): Promise<{ data: PorProcesso[]; total: number; error?: string; cid?: string }> => {
   const parsed = mapaRequestSchema.parse(params) as MapaTestemunhasRequest<ProcessoFilters>;
   const sanitized = {
     ...parsed,
@@ -274,7 +274,7 @@ export const fetchPorProcesso = async (
         payload: sanitized,
         error: { error: err, detail, hint, example }
       });
-      return { data: [], total: 0, error: message };
+      return { data: [], total: 0, error: message, cid };
     }
 
     if (error) {
@@ -295,7 +295,8 @@ export const fetchPorProcesso = async (
 
     return {
       data: payload.data || [],
-      total: payload.count || payload.total || 0
+      total: payload.count || payload.total || 0,
+      cid
     };
   } catch (error) {
     if (error instanceof FunctionsHttpError) {
@@ -365,14 +366,15 @@ export const fetchPorProcesso = async (
 
     return {
       data: filteredData.slice(start, end),
-      total: filteredData.length
+      total: filteredData.length,
+      cid
     };
   }
 };
 
 export const fetchPorTestemunha = async (
   params: MapaTestemunhasRequest<TestemunhaFilters>
-): Promise<{ data: PorTestemunha[]; total: number; error?: string }> => {
+): Promise<{ data: PorTestemunha[]; total: number; error?: string; cid?: string }> => {
   const parsed = mapaRequestSchema.parse(params) as MapaTestemunhasRequest<TestemunhaFilters>;
   const sanitized = {
     ...parsed,
@@ -421,7 +423,7 @@ export const fetchPorTestemunha = async (
         payload: sanitized,
         error: { error: err, detail, hint, example }
       });
-      return { data: [], total: 0, error: message };
+      return { data: [], total: 0, error: message, cid };
     }
 
     if (error) {
@@ -442,7 +444,8 @@ export const fetchPorTestemunha = async (
 
     return {
       data: payload.data || [],
-      total: payload.count || payload.total || 0
+      total: payload.count || payload.total || 0,
+      cid
     };
   } catch (error) {
     if (error instanceof FunctionsHttpError) {
@@ -483,7 +486,8 @@ export const fetchPorTestemunha = async (
 
     return {
       data: filteredData.slice(start, end),
-      total: filteredData.length
+      total: filteredData.length,
+      cid
     };
   }
 };

--- a/src/pages/MapaPage.tsx
+++ b/src/pages/MapaPage.tsx
@@ -23,6 +23,7 @@ import {
   selectIsPiiMasked,
   selectHasError,
   selectErrorMessage,
+  selectErrorCid,
   selectLastUpdate,
   selectProcessoFilters,
   selectTestemunhaFilters
@@ -73,6 +74,7 @@ const MapaPage = () => {
   const isPiiMasked = useMapaTestemunhasStore(selectIsPiiMasked);
   const hasError = useMapaTestemunhasStore(selectHasError);
   const errorMessage = useMapaTestemunhasStore(selectErrorMessage);
+  const errorCid = useMapaTestemunhasStore(selectErrorCid);
   const lastUpdate = useMapaTestemunhasStore(selectLastUpdate);
   const processoFilters = useMapaTestemunhasStore(selectProcessoFilters);
   const testemunhaFilters = useMapaTestemunhasStore(selectTestemunhaFilters);
@@ -188,7 +190,8 @@ const MapaPage = () => {
 
         const errorMsg = processosResult.error || testemunhasResult.error;
         if (errorMsg) {
-          setError(true, errorMsg);
+          const cid = processosResult.error ? processosResult.cid : testemunhasResult.cid;
+          setError(true, errorMsg, cid);
           toast({
             title: "Falha ao carregar dados",
             description: errorMsg,
@@ -294,12 +297,17 @@ const MapaPage = () => {
         {/* Error State */}
         {hasError && (
           <Card className="rounded-2xl border-destructive/50 bg-destructive/5 mb-6">
-            <CardContent className="p-4">
+            <CardContent className="p-4 space-y-1">
               <div className="flex items-center gap-2 text-destructive">
                 <AlertTriangle className="h-4 w-4" aria-hidden="true" />
                 <span className="font-medium">Erro:</span>
                 <span className="text-sm">{errorMessage}</span>
               </div>
+              {errorCid && (
+                <div className="text-xs text-destructive/70">
+                  ID de correlação: {errorCid}
+                </div>
+              )}
             </CardContent>
           </Card>
         )}


### PR DESCRIPTION
## Summary
- store correlation IDs for mapa-testemunhas errors
- propagate correlation IDs from fetch helpers and display on Mapa page

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c002ccdda0832282212cab1a4be634