### PR TITLE
test: copy error details from /mapa toast

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,13 @@ curl -X POST "$SUPABASE_URL/functions/v1/mapa-testemunhas-testemunhas" \
 npm run test
 ```
 
+### Teste manual: copiar detalhes do erro
+
+1. Force uma falha na página `/mapa` (ex.: desconecte a rede).
+2. Acesse `/mapa` e aguarde o toast de erro.
+3. Clique em **Copiar detalhes**.
+4. Cole em algum editor e verifique o objeto `{ route, status, cid, timestamp }`.
+
 ---
 
 ## 🔒 Segurança

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -225,7 +225,7 @@ const mapaRequestSchema = z.object({
 // Fetch functions with Supabase fallback to mocks
 export const fetchPorProcesso = async (
   params: MapaTestemunhasRequest<ProcessoFilters>
-): Promise<{ data: PorProcesso[]; total: number; error?: string }> => {
+): Promise<{ data: PorProcesso[]; total: number; error?: string; status?: number; cid?: string; route?: string }> => {
   const parsed = mapaRequestSchema.parse(params) as MapaTestemunhasRequest<ProcessoFilters>;
   const sanitized = {
     ...parsed,
@@ -274,7 +274,14 @@ export const fetchPorProcesso = async (
         payload: sanitized,
         error: { error: err, detail, hint, example }
       });
-      return { data: [], total: 0, error: message };
+      return {
+        data: [],
+        total: 0,
+        error: message,
+        status: error.context.response.status,
+        cid,
+        route: error.context.response.url,
+      };
     }
 
     if (error) {
@@ -372,7 +379,7 @@ export const fetchPorProcesso = async (
 
 export const fetchPorTestemunha = async (
   params: MapaTestemunhasRequest<TestemunhaFilters>
-): Promise<{ data: PorTestemunha[]; total: number; error?: string }> => {
+): Promise<{ data: PorTestemunha[]; total: number; error?: string; status?: number; cid?: string; route?: string }> => {
   const parsed = mapaRequestSchema.parse(params) as MapaTestemunhasRequest<TestemunhaFilters>;
   const sanitized = {
     ...parsed,
@@ -421,7 +428,14 @@ export const fetchPorTestemunha = async (
         payload: sanitized,
         error: { error: err, detail, hint, example }
       });
-      return { data: [], total: 0, error: message };
+      return {
+        data: [],
+        total: 0,
+        error: message,
+        status: error.context.response.status,
+        cid,
+        route: error.context.response.url,
+      };
     }
 
     if (error) {

--- a/src/pages/MapaPage.tsx
+++ b/src/pages/MapaPage.tsx
@@ -38,6 +38,7 @@ import { ExportCsvButton } from "@/components/mapa/ExportCsvButton";
 import { useToast } from "@/hooks/use-toast";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
+import { ToastAction } from "@/components/ui/toast";
 import { fetchPorProcesso, fetchPorTestemunha } from "@/lib/supabase";
 import { PorProcesso, PorTestemunha } from "@/types/mapa-testemunhas";
 import { normalizeMapaRequest } from "@/lib/normalizeMapaRequest";
@@ -186,13 +187,31 @@ const MapaPage = () => {
         setProcessos(processosResult.data);
         setTestemunhas(testemunhasResult.data);
 
-        const errorMsg = processosResult.error || testemunhasResult.error;
-        if (errorMsg) {
-          setError(true, errorMsg);
+        const errorResult = processosResult.error
+          ? processosResult
+          : testemunhasResult.error
+          ? testemunhasResult
+          : null;
+        if (errorResult) {
+          const details = {
+            route: errorResult.route,
+            status: errorResult.status,
+            cid: errorResult.cid,
+            timestamp: new Date().toISOString(),
+          };
+          setError(true, errorResult.error!);
           toast({
             title: "Falha ao carregar dados",
-            description: errorMsg,
+            description: errorResult.error,
             variant: "destructive",
+            action: (
+              <ToastAction
+                altText="Copiar detalhes"
+                onClick={() => navigator.clipboard.writeText(JSON.stringify(details))}
+              >
+                Copiar detalhes
+              </ToastAction>
+            ),
           });
         } else {
           if (isFirstLoad) {

--- a/tests/mapa-error-copy.test.tsx
+++ b/tests/mapa-error-copy.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: {}, loading: false })
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  fetchPorProcesso: vi.fn().mockResolvedValue({
+    data: [],
+    total: 0,
+    error: 'Falha',
+    status: 500,
+    cid: 'cid-123',
+    route: '/mapa-testemunhas-processos',
+  }),
+  fetchPorTestemunha: vi.fn().mockResolvedValue({ data: [], total: 0 })
+}))
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { Toaster } from '@/components/ui/toaster'
+import MapaPage from '@/pages/MapaPage'
+
+/**
+ * @vitest-environment jsdom
+ */
+
+describe('Mapa error copy', () => {
+  it('copies error details to clipboard', async () => {
+    const writeText = vi.fn()
+    ;(navigator as any).clipboard = { writeText }
+
+    render(
+      <MemoryRouter initialEntries={['/mapa']}>
+        <MapaPage />
+        <Toaster />
+      </MemoryRouter>
+    )
+
+    const copyBtn = await screen.findByRole('button', { name: /copiar detalhes/i })
+
+    await userEvent.click(copyBtn)
+
+    expect(writeText).toHaveBeenCalledTimes(1)
+    const payload = JSON.parse(writeText.mock.calls[0][0])
+    expect(payload).toMatchObject({
+      route: '/mapa-testemunhas-processos',
+      status: 500,
+      cid: 'cid-123',
+    })
+    expect(payload.timestamp).toBeDefined()
+    expect(payload.payload).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- add UI test ensuring error details from `/mapa` copy correctly
- propagate cid, route and status from Supabase helpers
- show "Copiar detalhes" action in error toast and document manual test

## Testing
- `npm test` *(fails: vitest not found)*
- `bun test` *(fails: missing packages and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c003058b9883228887a74ceb75a7c9