### PR TITLE
feat: centralize http responses for witness process function

### DIFF
--- a/supabase/functions/_shared/http.ts
+++ b/supabase/functions/_shared/http.ts
@@ -1,0 +1,40 @@
+import { buildCorsHeaders } from "./cors.ts";
+
+export function withCid(req: Request) {
+  let cid = req.headers.get("x-correlation-id");
+  if (!cid) {
+    cid = crypto.randomUUID();
+    req.headers.set("x-correlation-id", cid);
+  }
+  return { cid };
+}
+
+export function jres(
+  req: Request,
+  body: Record<string, unknown>,
+  status = 200,
+) {
+  const { cid } = withCid(req);
+  const headers = {
+    ...buildCorsHeaders(req),
+    "content-type": "application/json; charset=utf-8",
+    "x-correlation-id": cid,
+  };
+  return new Response(JSON.stringify({ ...body, cid }), {
+    status,
+    headers,
+  });
+}
+
+export function jerr(
+  req: Request,
+  cid: string,
+  status: number,
+  code: string,
+  details?: unknown,
+) {
+  req.headers.set("x-correlation-id", cid);
+  const payload: Record<string, unknown> = { error: code };
+  if (details !== undefined) payload.details = details;
+  return jres(req, payload, status);
+}


### PR DESCRIPTION
## Summary
- add shared HTTP helpers for correlation ID and JSON/CORS responses
- refactor `mapa-testemunhas-processos` to use new helpers and standardized errors

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fdom)*

------
https://chatgpt.com/codex/tasks/task_e_68c002fad5ec83228df83af20dc24a87