### PR TITLE
chore: log request metadata and sanitize console output

### DIFF
--- a/src/components/beta/BetaSignup.tsx
+++ b/src/components/beta/BetaSignup.tsx
@@ -99,7 +99,6 @@ export function BetaSignup({ compact = false, className = '', variant = 'inline'
     
     try {
       // Track form submission
-      console.log('beta_form_submitted', data);
       
       // Get UTM parameters
       const urlParams = new URLSearchParams(window.location.search);
@@ -123,7 +122,6 @@ export function BetaSignup({ compact = false, className = '', variant = 'inline'
 
         if (error) throw error;
 
-        console.log('beta_form_success', result);
         setIsSuccess(true);
         toast({
           title: 'Sucesso!',
@@ -131,10 +129,8 @@ export function BetaSignup({ compact = false, className = '', variant = 'inline'
         });
       } catch (apiError) {
         // Fallback to mock success
-        console.log('Using mock success - API not available');
         await new Promise(resolve => setTimeout(resolve, 700)); // Simulate API delay
         
-        console.log('beta_form_success (mock)', payload);
         setIsSuccess(true);
         toast({
           title: 'Sucesso!',
@@ -142,7 +138,6 @@ export function BetaSignup({ compact = false, className = '', variant = 'inline'
         });
       }
     } catch (error) {
-      console.error('beta_form_error', error);
       toast({
         title: 'Erro',
         description: 'Ocorreu um erro. Tente novamente em alguns instantes.',
@@ -157,8 +152,7 @@ export function BetaSignup({ compact = false, className = '', variant = 'inline'
     setIsSuccess(false);
     setShowEmailHint(false);
     setShowOutroText(false);
-    reset();
-    console.log('beta_form_opened');
+      reset();
   };
 
   if (isSuccess) {

--- a/src/lib/fetchWithAuth.ts
+++ b/src/lib/fetchWithAuth.ts
@@ -1,0 +1,29 @@
+import { ensureSessionOrThrow } from './supabaseClient';
+import { v4 as uuidv4 } from 'uuid';
+
+interface FetchWithAuthOptions extends RequestInit {
+  cid?: string;
+}
+
+export async function fetchWithAuth(route: string, options: FetchWithAuthOptions = {}) {
+  const { cid = uuidv4(), headers, ...init } = options;
+  const session = await ensureSessionOrThrow();
+  const token = session.access_token;
+  const start = Date.now();
+  try {
+    const response = await fetch(route, {
+      ...init,
+      headers: {
+        ...(headers || {}),
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const ms = Date.now() - start;
+    console.info(JSON.stringify({ route, status: response.status, ms, cid }));
+    return response;
+  } catch (error) {
+    const ms = Date.now() - start;
+    console.info(JSON.stringify({ route, status: 'error', ms, cid }));
+    throw error;
+  }
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -227,17 +227,10 @@ export const fetchPorProcesso = async (
   params: MapaTestemunhasRequest<ProcessoFilters>
 ): Promise<{ data: PorProcesso[]; total: number; error?: string }> => {
   const parsed = mapaRequestSchema.parse(params) as MapaTestemunhasRequest<ProcessoFilters>;
-  const sanitized = {
-    ...parsed,
-    filters: parsed.filters
-      ? Object.fromEntries(Object.keys(parsed.filters).map(k => [k, '[redacted]']))
-      : undefined
-  };
-  console.debug('mapa-testemunhas-processos payload', sanitized);
   let cid = uuidv4();
   try {
     if (!isSupabaseConfigured()) {
-      console.log('⚠️ Supabase not configured, using mock data');
+      console.info('Supabase not configured, using mock data');
       throw new Error('Supabase not configured');
     }
 
@@ -266,28 +259,23 @@ export const fetchPorProcesso = async (
         errorPayload = await error.context.response.json();
       } catch {}
 
-      const { error: err, detail, hint, example } = errorPayload || {};
+      const { detail, hint } = errorPayload || {};
       const message = detail || hint || 'Verifique filtros e tente novamente.';
-      console.error(`[cid=${cid}] fetchPorProcesso HTTP error`, {
-        status: error.context.response.status,
-        url: error.context.response.url,
-        payload: sanitized,
-        error: { error: err, detail, hint, example }
-      });
+      console.error(`[cid=${cid}] fetchPorProcesso HTTP error`, error.context.response.status);
       return { data: [], total: 0, error: message };
     }
 
     if (error) {
-      console.error(`[cid=${cid}] Error in fetchPorProcesso:`, error.message);
+      console.error(`[cid=${cid}] Error in fetchPorProcesso`, error.message);
       console.info(`[cid=${cid}] Hint: verifique filtros ou tente novamente.`);
       throw error;
     }
 
     const payload = data as { data?: PorProcesso[]; count?: number; total?: number };
     if (!payload?.data || payload.data.length === 0) {
-      console.log(`[cid=${cid}] 📊 Supabase returned empty processos dataset`);
+      console.info(`[cid=${cid}] Supabase returned empty processos dataset`);
     } else {
-      console.log(`[cid=${cid}] 📊 Fetched processos from API:`, {
+      console.info(`[cid=${cid}] Fetched processos from API`, {
         count: payload.data.length,
         total: payload.count || payload.total || 0
       });
@@ -302,7 +290,7 @@ export const fetchPorProcesso = async (
       console.error(`[cid=${cid}]`, mapFunctionsError(error));
       throw new Error(mapFunctionsError(error));
     }
-    console.warn(`[cid=${cid}] 📊 Request failed, using mock processos data:`, error);
+    console.warn(`[cid=${cid}] Request failed, using mock processos data`, (error as Error).message);
 
     // Mock filtering logic
     let filteredData = [...mockProcessos];
@@ -374,17 +362,10 @@ export const fetchPorTestemunha = async (
   params: MapaTestemunhasRequest<TestemunhaFilters>
 ): Promise<{ data: PorTestemunha[]; total: number; error?: string }> => {
   const parsed = mapaRequestSchema.parse(params) as MapaTestemunhasRequest<TestemunhaFilters>;
-  const sanitized = {
-    ...parsed,
-    filters: parsed.filters
-      ? Object.fromEntries(Object.keys(parsed.filters).map(k => [k, '[redacted]']))
-      : undefined
-  };
-  console.debug('mapa-testemunhas-testemunhas payload', sanitized);
   let cid = uuidv4();
   try {
     if (!isSupabaseConfigured()) {
-      console.log('⚠️ Supabase not configured, using mock data');
+      console.info('Supabase not configured, using mock data');
       throw new Error('Supabase not configured');
     }
 
@@ -413,28 +394,23 @@ export const fetchPorTestemunha = async (
         errorPayload = await error.context.response.json();
       } catch {}
 
-      const { error: err, detail, hint, example } = errorPayload || {};
+      const { detail, hint } = errorPayload || {};
       const message = detail || hint || 'Verifique filtros e tente novamente.';
-      console.error(`[cid=${cid}] fetchPorTestemunha HTTP error`, {
-        status: error.context.response.status,
-        url: error.context.response.url,
-        payload: sanitized,
-        error: { error: err, detail, hint, example }
-      });
+      console.error(`[cid=${cid}] fetchPorTestemunha HTTP error`, error.context.response.status);
       return { data: [], total: 0, error: message };
     }
 
     if (error) {
-      console.error(`[cid=${cid}] Error in fetchPorTestemunha:`, error.message);
+      console.error(`[cid=${cid}] Error in fetchPorTestemunha`, error.message);
       console.info(`[cid=${cid}] Hint: verifique filtros ou tente novamente.`);
       throw error;
     }
 
     const payload = data as { data?: PorTestemunha[]; count?: number; total?: number };
     if (!payload?.data || payload.data.length === 0) {
-      console.log(`[cid=${cid}] 📊 Supabase returned empty testemunhas dataset`);
+      console.info(`[cid=${cid}] Supabase returned empty testemunhas dataset`);
     } else {
-      console.log(`[cid=${cid}] 📊 Fetched testemunhas from API:`, {
+      console.info(`[cid=${cid}] Fetched testemunhas from API`, {
         count: payload.data.length,
         total: payload.count || payload.total || 0
       });
@@ -449,7 +425,7 @@ export const fetchPorTestemunha = async (
       console.error(`[cid=${cid}]`, mapFunctionsError(error));
       throw new Error(mapFunctionsError(error));
     }
-    console.warn(`[cid=${cid}] 📊 Request failed, using mock testemunhas data:`, error);
+    console.warn(`[cid=${cid}] Request failed, using mock testemunhas data`, (error as Error).message);
 
     // Mock filtering logic
     let filteredData = [...mockTestemunhas];

--- a/src/pages/MapaPage.tsx
+++ b/src/pages/MapaPage.tsx
@@ -200,7 +200,7 @@ const MapaPage = () => {
             setIsFirstLoad(false);
           }
 
-          console.log('Data loaded successfully:', {
+          console.info('MapaPage dados carregados', {
             processos: processosResult.data.length,
             testemunhas: testemunhasResult.data.length
           });
@@ -209,7 +209,9 @@ const MapaPage = () => {
         setIsLoading(false);
         
       } catch (error) {
-        console.error('Erro ao carregar dados:', error);
+        console.error('Erro ao carregar dados',
+          error instanceof Error ? error.message : String(error)
+        );
         const message = error instanceof Error
           ? error.message
           : 'Verifique filtros e tente novamente.';

--- a/src/pages/PublicHome.tsx
+++ b/src/pages/PublicHome.tsx
@@ -16,7 +16,6 @@ export default function PublicHome() {
   const [isBetaModalOpen, setIsBetaModalOpen] = useState(false);
 
   const handleBetaSignup = (data: { email: string; needs: string[]; otherNeed?: string }) => {
-    console.log('Beta signup data:', data);
     // Esta função será chamada quando o formulário for enviado com sucesso
   };
 

--- a/src/stores/useBetaFormStore.ts
+++ b/src/stores/useBetaFormStore.ts
@@ -75,9 +75,6 @@ export const useBetaFormStore = create<BetaFormStore>((set, get) => ({
         }
       } catch (apiError) {
         // Fallback para mock se API não existir
-        console.log('Beta signup mock data:', payload);
-        
-        // Simular delay da API
         await new Promise(resolve => setTimeout(resolve, 1000));
         
         success = true;
@@ -100,7 +97,7 @@ export const useBetaFormStore = create<BetaFormStore>((set, get) => ({
         return true;
       }
     } catch (error) {
-      console.error('Erro ao enviar inscrição beta:', error);
+      console.error('Erro ao enviar inscrição beta', (error as Error).message);
       
       const errorMessage = 'Não foi possível enviar. Tente novamente.';
       set({ 


### PR DESCRIPTION
## Summary
- add `fetchWithAuth` helper that logs `{route,status,ms,cid}`
- remove unsanitized payload logs from Supabase utilities and hooks
- scrub beta-related logging to avoid leaking submission data

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @testing-library/dom)*

------
https://chatgpt.com/codex/tasks/task_e_68c003042b90832299a40beb259d7e41