### PR TITLE
refactor: add json helpers and update processes deletion

### DIFF
--- a/supabase/functions/_shared/http.ts
+++ b/supabase/functions/_shared/http.ts
@@ -38,3 +38,25 @@ export function jerr(
   if (details !== undefined) payload.details = details;
   return jres(req, payload, status);
 }
+
+// New helpers without Request dependency
+export function json(
+  status: number,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+) {
+  const hdrs = new Headers({
+    "content-type": "application/json; charset=utf-8",
+    ...headers,
+  });
+  return new Response(JSON.stringify(body), { status, headers: hdrs });
+}
+
+export function jsonError(
+  status: number,
+  message: string,
+  details: Record<string, unknown> = {},
+  headers: Record<string, string> = {},
+) {
+  return json(status, { error: message, ...details }, headers);
+}

--- a/supabase/functions/processes-delete-all/index.ts
+++ b/supabase/functions/processes-delete-all/index.ts
@@ -1,60 +1,48 @@
 // Secure bulk deletion endpoint for processos
 // Endpoint: /functions/v1/processes-delete-all
 import { corsHeaders, handlePreflight } from "../_shared/cors.ts";
+import { json, jsonError } from "../_shared/http.ts";
 import { getAuth } from "../_shared/auth.ts";
 
 Deno.serve(async (req: Request) => {
-  const pre = handlePreflight(req);
-  if (pre) return pre;
-  
-  if (req.method !== "POST") {
-    return new Response(JSON.stringify({ error: "method_not_allowed" }), { 
-      status: 405, 
-      headers: corsHeaders(req) 
-    });
-  }
-
-  const { user, organization_id, role, supa } = await getAuth(req);
-  if (!user) {
-    return new Response(JSON.stringify({ error: "unauthorized" }), { 
-      status: 401, 
-      headers: corsHeaders(req) 
-    });
-  }
-  
-  if (!organization_id) {
-    return new Response(JSON.stringify({ error: "organization_not_found" }), { 
-      status: 400, 
-      headers: corsHeaders(req) 
-    });
-  }
-  
-  if (!["ADMIN"].includes(String(role))) {
-    return new Response(JSON.stringify({ error: "insufficient_permissions" }), { 
-      status: 403, 
-      headers: corsHeaders(req) 
-    });
-  }
-
-  const body = await req.json().catch(() => ({}));
-  const confirmText = body?.confirm;
-  const hardDelete = body?.hard_delete === true;
-  
-  if (confirmText !== organization_id) {
-    return new Response(JSON.stringify({ error: "confirmation_required" }), { 
-      status: 400, 
-      headers: corsHeaders(req) 
-    });
-  }
+  const cid = req.headers.get("x-correlation-id") ?? crypto.randomUUID();
+  const ch = corsHeaders(req);
+  const pf = handlePreflight(req, cid);
+  if (pf) return pf;
 
   try {
+    if (req.method !== "POST") {
+      return json(405, { error: "method_not_allowed", cid }, { ...ch, "x-correlation-id": cid });
+    }
+
+    const { user, organization_id, role, supa } = await getAuth(req);
+    if (!user) {
+      return json(401, { error: "unauthorized", cid }, { ...ch, "x-correlation-id": cid });
+    }
+
+    if (!organization_id) {
+      return json(400, { error: "organization_not_found", cid }, { ...ch, "x-correlation-id": cid });
+    }
+
+    if (!["ADMIN"].includes(String(role))) {
+      return json(403, { error: "insufficient_permissions", cid }, { ...ch, "x-correlation-id": cid });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const confirmText = body?.confirm;
+    const hardDelete = body?.hard_delete === true;
+
+    if (confirmText !== organization_id) {
+      return json(400, { error: "confirmation_required", cid }, { ...ch, "x-correlation-id": cid });
+    }
+
     // Count records before deletion
     const { count: beforeCount, error: countErr } = await supa
       .from("processos")
       .select("id", { head: true, count: "exact" })
       .eq("org_id", organization_id)
       .is("deleted_at", null);
-      
+
     if (countErr) {
       throw countErr;
     }
@@ -72,15 +60,15 @@ Deno.serve(async (req: Request) => {
       // Soft delete - recommended approach
       const { error } = await supa
         .from("processos")
-        .update({ 
-          deleted_at: new Date().toISOString(), 
-          deleted_by: user.id 
+        .update({
+          deleted_at: new Date().toISOString(),
+          deleted_by: user.id
         })
         .eq("org_id", organization_id)
         .is("deleted_at", null);
       deleteError = error;
     }
-    
+
     if (deleteError) {
       throw deleteError;
     }
@@ -91,33 +79,28 @@ Deno.serve(async (req: Request) => {
       .select("id", { head: true, count: "exact" })
       .eq("org_id", organization_id)
       .is("deleted_at", null);
-      
+
     if (afterErr) {
       throw afterErr;
     }
 
     const affectedCount = (beforeCount ?? 0) - (afterCount ?? 0);
 
-    return new Response(
-      JSON.stringify({ 
+    return json(
+      200,
+      {
         success: true,
         deleted_count: affectedCount,
         operation_type: hardDelete ? "HARD_DELETE" : "SOFT_DELETE",
         message: "Operação de exclusão concluída com sucesso",
         organization_id,
-        remaining_count: afterCount ?? 0
-      }),
-      { headers: corsHeaders(req) }
+        remaining_count: afterCount ?? 0,
+        cid,
+      },
+      { ...ch, "x-correlation-id": cid },
     );
-
-  } catch (error) {
-    console.error("❌ Deletion error:", error);
-    return new Response(
-      JSON.stringify({ 
-        error: "deletion_failed", 
-        message: error instanceof Error ? error.message : "Erro desconhecido"
-      }),
-      { status: 500, headers: corsHeaders(req) }
-    );
+  } catch (e) {
+    console.error(JSON.stringify({ cid, err: String(e) }));
+    return jsonError(500, "Erro interno", { cid }, { ...ch, "x-correlation-id": cid });
   }
 });


### PR DESCRIPTION
## Summary
- add generic `json` and `jsonError` helpers for Supabase edge functions
- refactor `processes-delete-all` function to use new handler with correlation id and CORS utilities

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c01b292a8883228f8114ff6c5de2ea