### PR TITLE
docs: add CORS setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@
 
 ---
 
+## 📚 Documentação
+
+- [Configuração de CORS](docs/cors-setup.md)
+
+---
+
 ## 📦 Como Rodar o Projeto
 
 ### 1. Clonar o repositório

--- a/docs/cors-setup.md
+++ b/docs/cors-setup.md
@@ -1,0 +1,24 @@
+# Configuração de CORS
+
+## 1. Definir variável no Dashboard
+No [Dashboard](https://supabase.com/dashboard): **Project Settings → Configuration → Secrets → NEW**
+
+Valor:
+
+```
+ALLOWED_ORIGINS="https://assistjur.com.br,https://www.assistjur.com.br,https://assistjur.com,https://www.assistjur.com,https://*.lovable.dev"
+```
+
+## 2. Alternativa via CLI
+Execute o comando abaixo substituindo `<REF>` pelo ID do projeto:
+
+```bash
+# Configura ALLOWED_ORIGINS para o ambiente de produção
+supabase secrets set --project-ref <REF> --env prod ALLOWED_ORIGINS="https://assistjur.com.br,https://www.assistjur.com.br,https://assistjur.com,https://www.assistjur.com,https://*.lovable.dev"
+```
+
+## 3. Nota de segurança
+Evite curingas amplos na configuração de CORS. O curinga `https://*.lovable.dev` é permitido apenas para pré-visualizações.
+
+## 4. Redeploy das funções
+Após atualizar o segredo, faça o redeploy das functions pelo Dashboard ou via CLI.


### PR DESCRIPTION
## Summary
- document how to configure ALLOWED_ORIGINS for CORS in Supabase
- link README to the new CORS setup guide

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fdom)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c01b29e6cc8322a9086b008f2a2a31