### PR TITLE
refactor: use Deno.serve in edge functions

### DIFF
--- a/supabase/functions/admin-analytics/index.ts
+++ b/supabase/functions/admin-analytics/index.ts
@@ -1,9 +1,8 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0';
 import { corsHeaders, handlePreflight } from '../_shared/cors.ts';
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   const cid = req.headers.get('x-correlation-id') ?? crypto.randomUUID();
   const pre = handlePreflight(req, cid);
   if (pre) return pre;

--- a/supabase/functions/admin-openai-keys/index.ts
+++ b/supabase/functions/admin-openai-keys/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0';
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 
@@ -57,7 +56,7 @@ async function testOpenAIKey(key: string): Promise<{ valid: boolean; model?: str
   }
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   console.log('🔑 OpenAI Keys Management Function');
   console.log('Method:', req.method, 'URL:', req.url);
 

--- a/supabase/functions/admin-openai-settings/index.ts
+++ b/supabase/functions/admin-openai-settings/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0';
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 
@@ -21,7 +20,7 @@ function decodeJWT(token: string) {
   }
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   console.log('⚙️ OpenAI Settings Function Started');
   console.log('Method:', req.method, 'URL:', req.url);
 

--- a/supabase/functions/admin-openai-test/index.ts
+++ b/supabase/functions/admin-openai-test/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0';
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 
@@ -7,7 +6,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   console.log('🧪 OpenAI Test Function Started');
   console.log('Method:', req.method);
 

--- a/supabase/functions/admin-prompts/index.ts
+++ b/supabase/functions/admin-prompts/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0';
 
 const corsHeaders = {
@@ -6,7 +5,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   console.log('📝 Prompts Management Function Started');
   console.log('Method:', req.method);
 

--- a/supabase/functions/assistjur-processos/index.ts
+++ b/supabase/functions/assistjur-processos/index.ts
@@ -1,10 +1,9 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2.56.0";
 import { corsHeaders, handlePreflight } from "../_shared/cors.ts";
 import { json, jsonError } from "../_shared/http.ts";
 import { z } from "npm:zod@3.23.8";
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   const cid = req.headers.get("x-correlation-id") ?? crypto.randomUUID();
   const ch = corsHeaders(req);
   const pf = handlePreflight(req, cid);

--- a/supabase/functions/assistjur-stats/index.ts
+++ b/supabase/functions/assistjur-stats/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0'
 import { getAuth } from "../_shared/auth.ts"
 
@@ -7,7 +6,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });

--- a/supabase/functions/automated-retention/index.ts
+++ b/supabase/functions/automated-retention/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0';
 
 const corsHeaders = {
@@ -6,7 +5,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });

--- a/supabase/functions/beta-signup/index.ts
+++ b/supabase/functions/beta-signup/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2.56.0";
 
 const corsHeaders = {
@@ -117,4 +116,4 @@ const handler = async (req: Request): Promise<Response> => {
   }
 };
 
-serve(handler);
+Deno.serve(handler);

--- a/supabase/functions/chat-legal/index.ts
+++ b/supabase/functions/chat-legal/index.ts
@@ -1,7 +1,6 @@
 // supabase/functions/chat-legal/index.ts
 
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { z } from "npm:zod@3.23.8";
 import { getSystemPrompt } from "../_shared/prompt-registry.ts";
 import { corsHeaders, handlePreflight } from "../_shared/cors.ts";
@@ -161,4 +160,4 @@ export async function handler(request: Request) {
   }
 }
 
-serve(handler);
+Deno.serve(handler);

--- a/supabase/functions/create-version/index.ts
+++ b/supabase/functions/create-version/index.ts
@@ -1,9 +1,8 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0'
 
 import { corsHeaders, handlePreflight } from '../_shared/cors.ts';
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   console.log(`create-version called: ${req.method} from ${req.headers.get("Origin")}`);
 
   const cid = req.headers.get('x-correlation-id') ?? crypto.randomUUID();

--- a/supabase/functions/data-retention/index.ts
+++ b/supabase/functions/data-retention/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0';
 
 const corsHeaders = {
@@ -6,7 +5,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });

--- a/supabase/functions/get-last-update/index.ts
+++ b/supabase/functions/get-last-update/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0'
 
 const corsHeaders = {
@@ -6,7 +5,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/import-assistjur-xlsx/index.ts
+++ b/supabase/functions/import-assistjur-xlsx/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0';
 import * as XLSX from 'https://deno.land/x/sheetjs@v0.18.3/xlsx.mjs';
 
@@ -495,7 +494,7 @@ function calculateAnalyticFlags(processos: ProcessoRow[], testemunhas: Testemunh
   return { processosEnhanced, testemunhasEnhanced, issues };
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });

--- a/supabase/functions/import-into-version/index.ts
+++ b/supabase/functions/import-into-version/index.ts
@@ -1,10 +1,9 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0'
 import { corsHeaders, handlePreflight } from '../_shared/cors.ts'
 
 console.log('🚀 import-into-version function starting - CORS fix applied...');
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   console.log(`📞 import-into-version called with method: ${req.method}, origin: ${req.headers.get('origin')}`);
 
   const cid = req.headers.get('x-correlation-id') ?? crypto.randomUUID();

--- a/supabase/functions/import-mapa-testemunhas/index.ts
+++ b/supabase/functions/import-mapa-testemunhas/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2.56.0";
 
 const corsHeaders = {
@@ -6,7 +5,7 @@ const corsHeaders = {
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
 };
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/lgpd-requests/index.ts
+++ b/supabase/functions/lgpd-requests/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0';
 
 const corsHeaders = {
@@ -6,7 +5,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });

--- a/supabase/functions/manage-user-roles/index.ts
+++ b/supabase/functions/manage-user-roles/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2.56.0";
 import { corsHeaders, handlePreflight } from "../_shared/cors.ts";
 
@@ -182,4 +181,4 @@ const handler = async (req: Request): Promise<Response> => {
   }
 };
 
-serve(handler);
+Deno.serve(handler);

--- a/supabase/functions/mapa-testemunhas-analysis/index.ts
+++ b/supabase/functions/mapa-testemunhas-analysis/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0'
 
 const corsHeaders = {
@@ -74,7 +73,7 @@ interface PadroesAgregados {
   concentracao_uf: { [key: string]: number }
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/mapa-testemunhas-processos/index.ts
+++ b/supabase/functions/mapa-testemunhas-processos/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2.56.0";
 import { handlePreflight, corsHeaders } from "../_shared/cors.ts";
 import { createLogger } from "../_shared/logger.ts";
@@ -6,7 +5,7 @@ import { ProcessosRequestSchema, ListaResponseSchema } from "../_shared/mapa-con
 import { json, jsonError } from "../_shared/http.ts";
 import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   let cid = req.headers.get("x-correlation-id") ?? crypto.randomUUID();
   req.headers.set("x-correlation-id", cid);
   const logger = createLogger(cid);

--- a/supabase/functions/mapa-testemunhas-testemunhas/index.ts
+++ b/supabase/functions/mapa-testemunhas-testemunhas/index.ts
@@ -1,11 +1,10 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2.56.0";
 import { corsHeaders, handlePreflight } from "../_shared/cors.ts";
 import { createLogger } from "../_shared/logger.ts";
 import { TestemunhasRequestSchema, ListaResponseSchema } from "../_shared/mapa-contracts.ts";
 import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   const cid = req.headers.get("x-correlation-id") ?? crypto.randomUUID();
   const logger = createLogger(cid);
 

--- a/supabase/functions/process-base-upload/index.ts
+++ b/supabase/functions/process-base-upload/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.224.0/http/server.ts"
 import { getAuth } from "../_shared/auth.ts"
 import * as XLSX from "https://deno.land/x/sheetjs@v0.18.3/xlsx.mjs"
 import "https://deno.land/x/xhr@0.1.0/mod.ts"
@@ -64,7 +63,7 @@ interface ValidationResult {
 
 // CNJ validation and duplicate checking will be handled by the advanced functions later in the file
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   console.log('📊 Base Upload Function Started');
   console.log('Method:', req.method, 'URL:', req.url);
 

--- a/supabase/functions/process-witness-data/index.ts
+++ b/supabase/functions/process-witness-data/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0'
 
 const corsHeaders = {
@@ -6,7 +5,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/publish-version/index.ts
+++ b/supabase/functions/publish-version/index.ts
@@ -1,8 +1,7 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0'
 import { corsHeaders, handlePreflight } from '../_shared/cors.ts'
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   const cid = req.headers.get('x-correlation-id') ?? crypto.randomUUID();
   const ch = corsHeaders(req);
   const pre = handlePreflight(req, cid);

--- a/supabase/functions/review-update-dados/index.ts
+++ b/supabase/functions/review-update-dados/index.ts
@@ -1,5 +1,4 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0';
 
 // CORS headers
@@ -41,7 +40,7 @@ interface ReviewResponse {
   duration_ms: number;
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });

--- a/supabase/functions/rollback-version/index.ts
+++ b/supabase/functions/rollback-version/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0'
 
 const corsHeaders = {
@@ -6,7 +5,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/security-demo/index.ts
+++ b/supabase/functions/security-demo/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { corsHeaders, validateJWT, createSecureErrorResponse, checkRateLimit, sanitizeAndValidate, secureLog, withTimeout, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS } from "../_shared/security.ts";
 import { z } from "npm:zod@4.1.3";
 
@@ -44,4 +43,4 @@ export async function handler(req: Request): Promise<Response> {
   }
 }
 
-serve(handler);
+Deno.serve(handler);

--- a/supabase/functions/templates-csv/index.ts
+++ b/supabase/functions/templates-csv/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { corsHeaders, handlePreflight } from '../_shared/cors.ts'
 
 // Generate valid CNJ with correct check digits
@@ -512,7 +511,7 @@ function buildCsv(sheetName: string): string {
   return lines.join('\n');
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   const cid = req.headers.get('x-correlation-id') ?? crypto.randomUUID();
   const ch = corsHeaders(req);
   const pre = handlePreflight(req, cid);

--- a/supabase/functions/templates-xlsx/index.ts
+++ b/supabase/functions/templates-xlsx/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { corsHeaders, handlePreflight } from '../_shared/cors.ts'
 
 // Import XLSX for Deno - using ESM.sh for better compatibility
@@ -443,7 +442,7 @@ function buildTemplateXlsx(): Uint8Array {
   });
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   const cid = req.headers.get('x-correlation-id') ?? crypto.randomUUID();
   const ch = corsHeaders(req);
   const pre = handlePreflight(req, cid);

--- a/supabase/functions/user-invitations/index.ts
+++ b/supabase/functions/user-invitations/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2.56.0";
 import { corsHeaders, handlePreflight } from "../_shared/cors.ts";
 import { json, jsonError } from "../_shared/http.ts";
@@ -158,4 +157,4 @@ const handler = async (req: Request): Promise<Response> => {
   }
 };
 
-serve(handler);
+Deno.serve(handler);


### PR DESCRIPTION
## Summary
- replace std `serve` imports with built-in `Deno.serve`
- keep standard correlation ID, CORS, and preflight handling

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for @testing-library/dom)*

------
https://chatgpt.com/codex/tasks/task_e_68c02b9a936c832283693d6f07d49cee