### PR TITLE
feat: support abortable fetch for supabase

### DIFF
--- a/tests/supabase-abort.test.ts
+++ b/tests/supabase-abort.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session: { access_token: 'token' } } })
+    }
+  }
+}))
+
+import { fetchPorProcesso, fetchPorTestemunha } from '../src/lib/supabase'
+
+describe('fetch functions abort', () => {
+  it('aborts fetchPorProcesso when controller aborts', async () => {
+    const controller = new AbortController()
+    const fetchMock = vi.fn((url: string, options: any) =>
+      new Promise((resolve, reject) => {
+        options.signal.addEventListener('abort', () =>
+          reject(new DOMException('Aborted', 'AbortError'))
+        )
+        setTimeout(() =>
+          resolve(new Response(JSON.stringify({ data: [], total: 0 }), { status: 200 })),
+        1000)
+      })
+    )
+    ;(global as any).fetch = fetchMock
+
+    const promise = fetchPorProcesso({ page: 1, limit: 1, filters: {} }, controller.signal)
+    controller.abort()
+    await expect(promise).rejects.toThrowError(DOMException)
+    expect(fetchMock).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ signal: controller.signal }))
+  })
+
+  it('aborts fetchPorTestemunha when controller aborts', async () => {
+    const controller = new AbortController()
+    const fetchMock = vi.fn((url: string, options: any) =>
+      new Promise((resolve, reject) => {
+        options.signal.addEventListener('abort', () =>
+          reject(new DOMException('Aborted', 'AbortError'))
+        )
+        setTimeout(() =>
+          resolve(new Response(JSON.stringify({ data: [], total: 0 }), { status: 200 })),
+        1000)
+      })
+    )
+    ;(global as any).fetch = fetchMock
+
+    const promise = fetchPorTestemunha({ page: 1, limit: 1, filters: {} }, controller.signal)
+    controller.abort()
+    await expect(promise).rejects.toThrowError(DOMException)
+    expect(fetchMock).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ signal: controller.signal }))
+  })
+})


### PR DESCRIPTION
## Summary
- use native fetch with AbortSignal for Supabase edge calls
- add tests covering AbortController behavior

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fdom)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c157c315348322bace909981eac80d