### PR TITLE
feat: add advanced mapa filters

### DIFF
--- a/src/contracts/mapa-contracts.ts
+++ b/src/contracts/mapa-contracts.ts
@@ -10,6 +10,15 @@ const ProcessosFiltroSchema = z
     search: z.string().trim().optional(),
     data_inicio: z.string().trim().optional(),
     data_fim: z.string().trim().optional(),
+    uf: z.string().trim().optional(),
+    status: z.string().trim().optional(),
+    fase: z.string().trim().optional(),
+    testemunha: z.string().trim().optional(),
+    qtd_depoimentos_min: z.coerce.number().int().optional(),
+    qtd_depoimentos_max: z.coerce.number().int().optional(),
+    tem_triangulacao: z.coerce.boolean().optional(),
+    tem_troca: z.coerce.boolean().optional(),
+    tem_prova_emprestada: z.coerce.boolean().optional(),
   })
   .default({});
 
@@ -29,10 +38,14 @@ const TestemunhasFiltroSchema = z
     search: z.string().trim().optional(),
     data_inicio: z.string().trim().optional(),
     data_fim: z.string().trim().optional(),
+    ambos_polos: z.coerce.boolean().optional(),
+    ja_foi_reclamante: z.coerce.boolean().optional(),
+    qtd_depoimentos_min: z.coerce.number().int().optional(),
+    qtd_depoimentos_max: z.coerce.number().int().optional(),
+    tem_triangulacao: z.coerce.boolean().optional(),
+    tem_troca: z.coerce.boolean().optional(),
   })
-  .refine((f) => !!(f.nome || f.documento || f.search), {
-    message: 'Pelo menos um filtro é obrigatório (nome, documento ou search)',
-  });
+  .default({});
 
 export const TestemunhasRequestSchema = z
   .object({

--- a/supabase/functions/_shared/mapa-contracts.ts
+++ b/supabase/functions/_shared/mapa-contracts.ts
@@ -14,6 +14,15 @@ const ProcessosFiltroSchema = z
     search: z.string().trim().optional(),
     data_inicio: z.string().trim().optional(),
     data_fim: z.string().trim().optional(),
+    uf: z.string().trim().optional(),
+    status: z.string().trim().optional(),
+    fase: z.string().trim().optional(),
+    testemunha: z.string().trim().optional(),
+    qtd_depoimentos_min: z.coerce.number().int().optional(),
+    qtd_depoimentos_max: z.coerce.number().int().optional(),
+    tem_triangulacao: z.coerce.boolean().optional(),
+    tem_troca: z.coerce.boolean().optional(),
+    tem_prova_emprestada: z.coerce.boolean().optional(),
   })
   .default({});
 
@@ -38,10 +47,14 @@ const TestemunhasFiltroSchema = z
     search: z.string().trim().optional(),
     data_inicio: z.string().trim().optional(),
     data_fim: z.string().trim().optional(),
+    ambos_polos: z.coerce.boolean().optional(),
+    ja_foi_reclamante: z.coerce.boolean().optional(),
+    qtd_depoimentos_min: z.coerce.number().int().optional(),
+    qtd_depoimentos_max: z.coerce.number().int().optional(),
+    tem_triangulacao: z.coerce.boolean().optional(),
+    tem_troca: z.coerce.boolean().optional(),
   })
-  .refine((f) => !!(f.nome || f.documento || f.search), {
-    message: "Pelo menos um filtro é obrigatório (nome, documento ou search)",
-  });
+  .default({});
 
 export const TestemunhasRequestSchema = z
   .object({
@@ -61,6 +74,7 @@ export const ListaResponseSchema = z.object({
   items: z.array(z.unknown()),
   page: z.number().int().min(1),
   limit: z.number().int().min(1).max(100),
+  total: z.number().int().nonnegative(),
   next_cursor: z.null().default(null),
   cid: z.string(),
 });

--- a/supabase/functions/_shared/mapa-filters.ts
+++ b/supabase/functions/_shared/mapa-filters.ts
@@ -1,0 +1,77 @@
+export function applyProcessosFilters(query: any, filtros: any) {
+  if (filtros.search) {
+    query = query.ilike("search", `%${filtros.search}%`);
+  }
+  if (filtros.data_inicio) {
+    query = query.gte("data", filtros.data_inicio);
+  }
+  if (filtros.data_fim) {
+    query = query.lte("data", filtros.data_fim);
+  }
+  if (filtros.uf) {
+    query = query.eq("uf", filtros.uf);
+  }
+  if (filtros.status) {
+    query = query.eq("status", filtros.status);
+  }
+  if (filtros.fase) {
+    query = query.eq("fase", filtros.fase);
+  }
+  if (filtros.testemunha) {
+    query = query.contains("todas_testemunhas", [filtros.testemunha]);
+  }
+  if (filtros.qtd_depoimentos_min !== undefined) {
+    query = query.gte("qtd_total_depos_unicos", filtros.qtd_depoimentos_min);
+  }
+  if (filtros.qtd_depoimentos_max !== undefined) {
+    query = query.lte("qtd_total_depos_unicos", filtros.qtd_depoimentos_max);
+  }
+  if (filtros.tem_triangulacao !== undefined) {
+    query = query.eq("triangulacao_confirmada", filtros.tem_triangulacao);
+  }
+  if (filtros.tem_troca !== undefined) {
+    query = query.eq("troca_direta", filtros.tem_troca);
+  }
+  if (filtros.tem_prova_emprestada !== undefined) {
+    query = query.eq("contem_prova_emprestada", filtros.tem_prova_emprestada);
+  }
+  return query;
+}
+
+export function applyTestemunhasFilters(query: any, filtros: any) {
+  if (filtros.nome) {
+    query = query.ilike("nome", `%${filtros.nome}%`);
+  }
+  if (filtros.documento) {
+    query = query.eq("documento", filtros.documento);
+  }
+  if (filtros.search) {
+    query = query.ilike("search", `%${filtros.search}%`);
+  }
+  if (filtros.data_inicio) {
+    query = query.gte("data", filtros.data_inicio);
+  }
+  if (filtros.data_fim) {
+    query = query.lte("data", filtros.data_fim);
+  }
+  if (filtros.ambos_polos !== undefined) {
+    query = query.eq("foi_testemunha_em_ambos_polos", filtros.ambos_polos);
+  }
+  if (filtros.ja_foi_reclamante !== undefined) {
+    query = query.eq("ja_foi_reclamante", filtros.ja_foi_reclamante);
+  }
+  if (filtros.qtd_depoimentos_min !== undefined) {
+    query = query.gte("qtd_depoimentos", filtros.qtd_depoimentos_min);
+  }
+  if (filtros.qtd_depoimentos_max !== undefined) {
+    query = query.lte("qtd_depoimentos", filtros.qtd_depoimentos_max);
+  }
+  if (filtros.tem_triangulacao !== undefined) {
+    query = query.eq("participou_triangulacao", filtros.tem_triangulacao);
+  }
+  if (filtros.tem_troca !== undefined) {
+    query = query.eq("participou_troca_favor", filtros.tem_troca);
+  }
+  return query;
+}
+

--- a/supabase/functions/mapa-testemunhas-processos/index.ts
+++ b/supabase/functions/mapa-testemunhas-processos/index.ts
@@ -2,6 +2,7 @@ import { createClient } from "npm:@supabase/supabase-js@2.56.0";
 import { corsHeaders, handlePreflight } from "../_shared/cors.ts";
 import { createLogger } from "../_shared/logger.ts";
 import { ListaResponseSchema, ProcessosRequestSchema } from "../_shared/mapa-contracts.ts";
+import { applyProcessosFilters } from "../_shared/mapa-filters.ts";
 import { json, jsonError } from "../_shared/http.ts";
 import { z } from "npm:zod@3.23.8";
 
@@ -56,15 +57,7 @@ Deno.serve(async (req) => {
     .select("*", { count: "exact" })
     .range(from, to);
 
-  if (filtros.search) {
-    query = query.ilike("search", `%${filtros.search}%`);
-  }
-  if (filtros.data_inicio) {
-    query = query.gte("data", filtros.data_inicio);
-  }
-  if (filtros.data_fim) {
-    query = query.lte("data", filtros.data_fim);
-  }
+  query = applyProcessosFilters(query, filtros);
 
   const { data, count, error } = await query;
   if (error) {
@@ -82,3 +75,4 @@ Deno.serve(async (req) => {
   logger.info(`success: ${result.items.length} items returned`);
   return json(200, result, { ...ch, "x-correlation-id": cid });
 });
+

--- a/supabase/functions/mapa-testemunhas-testemunhas/index.ts
+++ b/supabase/functions/mapa-testemunhas-testemunhas/index.ts
@@ -2,6 +2,7 @@ import { createClient } from "npm:@supabase/supabase-js@2.56.0";
 import { corsHeaders, handlePreflight } from "../_shared/cors.ts";
 import { createLogger } from "../_shared/logger.ts";
 import { ListaResponseSchema, TestemunhasRequestSchema } from "../_shared/mapa-contracts.ts";
+import { applyTestemunhasFilters } from "../_shared/mapa-filters.ts";
 import { json, jsonError } from "../_shared/http.ts";
 import { z } from "npm:zod@3.23.8";
 
@@ -56,21 +57,7 @@ Deno.serve(async (req) => {
     .select("*", { count: "exact" })
     .range(from, to);
 
-  if (filtros.nome) {
-    query = query.ilike("nome", `%${filtros.nome}%`);
-  }
-  if (filtros.documento) {
-    query = query.eq("documento", filtros.documento);
-  }
-  if (filtros.search) {
-    query = query.ilike("search", `%${filtros.search}%`);
-  }
-  if (filtros.data_inicio) {
-    query = query.gte("data", filtros.data_inicio);
-  }
-  if (filtros.data_fim) {
-    query = query.lte("data", filtros.data_fim);
-  }
+  query = applyTestemunhasFilters(query, filtros);
 
   const { data, count, error } = await query;
   if (error) {
@@ -88,3 +75,4 @@ Deno.serve(async (req) => {
   logger.info(`success: ${result.items.length} items returned`);
   return json(200, result, { ...ch, "x-correlation-id": cid });
 });
+

--- a/tests/mapa-filters.test.ts
+++ b/tests/mapa-filters.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment node
+ */
+
+import { describe, it, expect } from 'vitest';
+import { applyProcessosFilters, applyTestemunhasFilters } from '../supabase/functions/_shared/mapa-filters';
+
+class MockQuery {
+  calls: any[] = [];
+  ilike(field: string, value: any) {
+    this.calls.push(['ilike', field, value]);
+    return this;
+  }
+  eq(field: string, value: any) {
+    this.calls.push(['eq', field, value]);
+    return this;
+  }
+  gte(field: string, value: any) {
+    this.calls.push(['gte', field, value]);
+    return this;
+  }
+  lte(field: string, value: any) {
+    this.calls.push(['lte', field, value]);
+    return this;
+  }
+  contains(field: string, value: any) {
+    this.calls.push(['contains', field, value]);
+    return this;
+  }
+}
+
+describe('applyProcessosFilters', () => {
+  const cases: Array<{ name: string; filtro: any; expected: any[] }> = [
+    { name: 'search', filtro: { search: 'abc' }, expected: ['ilike', 'search', '%abc%'] },
+    { name: 'data_inicio', filtro: { data_inicio: '2020-01-01' }, expected: ['gte', 'data', '2020-01-01'] },
+    { name: 'data_fim', filtro: { data_fim: '2020-12-31' }, expected: ['lte', 'data', '2020-12-31'] },
+    { name: 'uf', filtro: { uf: 'SP' }, expected: ['eq', 'uf', 'SP'] },
+    { name: 'status', filtro: { status: 'Ativo' }, expected: ['eq', 'status', 'Ativo'] },
+    { name: 'fase', filtro: { fase: 'Execucao' }, expected: ['eq', 'fase', 'Execucao'] },
+    { name: 'testemunha', filtro: { testemunha: 'Joao' }, expected: ['contains', 'todas_testemunhas', ['Joao']] },
+    { name: 'qtd_depoimentos_min', filtro: { qtd_depoimentos_min: 2 }, expected: ['gte', 'qtd_total_depos_unicos', 2] },
+    { name: 'qtd_depoimentos_max', filtro: { qtd_depoimentos_max: 5 }, expected: ['lte', 'qtd_total_depos_unicos', 5] },
+    { name: 'tem_triangulacao', filtro: { tem_triangulacao: true }, expected: ['eq', 'triangulacao_confirmada', true] },
+    { name: 'tem_troca', filtro: { tem_troca: true }, expected: ['eq', 'troca_direta', true] },
+    { name: 'tem_prova_emprestada', filtro: { tem_prova_emprestada: true }, expected: ['eq', 'contem_prova_emprestada', true] },
+  ];
+
+  cases.forEach(({ name, filtro, expected }) => {
+    it(`applies ${name}`, () => {
+      const q = new MockQuery();
+      applyProcessosFilters(q, filtro);
+      expect(q.calls).toContainEqual(expected);
+    });
+  });
+});
+
+describe('applyTestemunhasFilters', () => {
+  const cases: Array<{ name: string; filtro: any; expected: any[] }> = [
+    { name: 'nome', filtro: { nome: 'Ana' }, expected: ['ilike', 'nome', '%Ana%'] },
+    { name: 'documento', filtro: { documento: '123' }, expected: ['eq', 'documento', '123'] },
+    { name: 'search', filtro: { search: 'abc' }, expected: ['ilike', 'search', '%abc%'] },
+    { name: 'data_inicio', filtro: { data_inicio: '2020-01-01' }, expected: ['gte', 'data', '2020-01-01'] },
+    { name: 'data_fim', filtro: { data_fim: '2020-12-31' }, expected: ['lte', 'data', '2020-12-31'] },
+    { name: 'ambos_polos', filtro: { ambos_polos: true }, expected: ['eq', 'foi_testemunha_em_ambos_polos', true] },
+    { name: 'ja_foi_reclamante', filtro: { ja_foi_reclamante: true }, expected: ['eq', 'ja_foi_reclamante', true] },
+    { name: 'qtd_depoimentos_min', filtro: { qtd_depoimentos_min: 2 }, expected: ['gte', 'qtd_depoimentos', 2] },
+    { name: 'qtd_depoimentos_max', filtro: { qtd_depoimentos_max: 5 }, expected: ['lte', 'qtd_depoimentos', 5] },
+    { name: 'tem_triangulacao', filtro: { tem_triangulacao: true }, expected: ['eq', 'participou_triangulacao', true] },
+    { name: 'tem_troca', filtro: { tem_troca: true }, expected: ['eq', 'participou_troca_favor', true] },
+  ];
+
+  cases.forEach(({ name, filtro, expected }) => {
+    it(`applies ${name}`, () => {
+      const q = new MockQuery();
+      applyTestemunhasFilters(q, filtro);
+      expect(q.calls).toContainEqual(expected);
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- extend mapa contratos with expanded filter fields and total count
- share filter application helpers
- apply filters in edge functions and add unit tests

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest run` *(fails: 403 Forbidden downloading vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68c15bf44d188322b7e88f6a2a3ba2a3