### PR TITLE
Use env variables for Supabase client

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,8 +1,16 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '@/integrations/supabase/types'
 
-const SUPABASE_URL = 'https://fgjypmlszuzkgvhuszxn.supabase.co'
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZnanlwbWxzenV6a2d2aHVzenhuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYwMzE4MjQsImV4cCI6MjA3MTYwNzgyNH0.lN-Anhn1e-2SCDIAe6megYRHdhofe1VO71D6-Zk70XU'
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY
+
+if (!SUPABASE_URL) {
+  throw new Error('Missing VITE_SUPABASE_URL environment variable')
+}
+
+if (!SUPABASE_ANON_KEY) {
+  throw new Error('Missing VITE_SUPABASE_PUBLISHABLE_KEY environment variable')
+}
 
 let client: SupabaseClient<Database>
 

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,11 +1,14 @@
-import { expect, afterEach } from 'vitest';
-import { cleanup } from '@testing-library/react';
-import * as matchers from '@testing-library/jest-dom/matchers';
+import { expect, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import * as matchers from '@testing-library/jest-dom/matchers'
+
+process.env.VITE_SUPABASE_URL ??= 'https://example.supabase.co'
+process.env.VITE_SUPABASE_PUBLISHABLE_KEY ??= 'anon-key'
 
 // Extends Vitest's expect method with methods from react-testing-library
-expect.extend(matchers);
+expect.extend(matchers)
 
 // Runs a cleanup after each test case (e.g. clearing jsdom)
 afterEach(() => {
-  cleanup();
-});
+  cleanup()
+})

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL: string
+  readonly VITE_SUPABASE_PUBLISHABLE_KEY: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary
- load Supabase credentials from Vite environment variables
- validate required Supabase env vars and surface clear errors
- configure test setup with default Supabase env vars

## Testing
- `npm install` (fails: 403 Forbidden fetching packages)
- `npx vitest run` (fails: 403 Forbidden fetching packages)
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68c1753759748322a506fefb56e9deb9