### PR TITLE
refactor: restrict CORS allow origin

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -22,12 +22,10 @@ function matchOrigin(origin: string, patterns: string[]) {
 }
 
 export function corsHeaders(req: Request) {
-  const { raw, patterns } = parseAllowedOrigins();
+  const { patterns } = parseAllowedOrigins();
   const origin = req.headers.get("origin") ?? "";
   const headers: Record<string, string> = { ...DEFAULT_HEADERS };
-  if (raw.length === 0) {
-    headers["Access-Control-Allow-Origin"] = "*";
-  } else if (matchOrigin(origin, patterns)) {
+  if (matchOrigin(origin, patterns)) {
     headers["Access-Control-Allow-Origin"] = origin;
   }
   return headers;

--- a/tests/cors.test.ts
+++ b/tests/cors.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { corsHeaders } from '../supabase/functions/_shared/cors';
+
+function setAllowedOrigins(value?: string) {
+  (globalThis as any).Deno = {
+    env: {
+      get: (name: string) => (name === 'ALLOWED_ORIGINS' ? value : undefined),
+    },
+  } as any;
+}
+
+afterEach(() => {
+  // clean up Deno mock
+  // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+  delete (globalThis as any).Deno;
+});
+
+describe('corsHeaders', () => {
+  it('does not set header when ALLOWED_ORIGINS is unset', () => {
+    setAllowedOrigins(undefined);
+    const req = new Request('https://example.com', {
+      headers: { origin: 'https://foo.com' },
+    });
+    const headers = corsHeaders(req);
+    expect(headers['Access-Control-Allow-Origin']).toBeUndefined();
+  });
+
+  it('sets header when origin matches allowed list', () => {
+    setAllowedOrigins('https://allowed.com');
+    const req = new Request('https://example.com', {
+      headers: { origin: 'https://allowed.com' },
+    });
+    const headers = corsHeaders(req);
+    expect(headers['Access-Control-Allow-Origin']).toBe('https://allowed.com');
+  });
+
+  it('does not set header when origin does not match', () => {
+    setAllowedOrigins('https://allowed.com');
+    const req = new Request('https://example.com', {
+      headers: { origin: 'https://other.com' },
+    });
+    const headers = corsHeaders(req);
+    expect(headers['Access-Control-Allow-Origin']).toBeUndefined();
+  });
+});
+


### PR DESCRIPTION
## Summary
- remove wildcard fallback and only set `Access-Control-Allow-Origin` for configured origins
- add unit tests for `corsHeaders` with and without `ALLOWED_ORIGINS`

## Testing
- `npm test -- tests/cors.test.ts` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden from registry.npmjs.org)*


------
https://chatgpt.com/codex/tasks/task_e_68c17a6104a083229ea0d26b3f5cd97f