### PR TITLE
fix: enforce allowed origins for mapa endpoints

### DIFF
--- a/supabase/functions/mapa-testemunhas-analysis/index.ts
+++ b/supabase/functions/mapa-testemunhas-analysis/index.ts
@@ -71,7 +71,8 @@ interface PadroesAgregados {
 
 Deno.serve(async (req) => {
   const cid = req.headers.get('x-correlation-id') ?? crypto.randomUUID();
-  const ch = corsHeaders(req);
+  const origin = req.headers.get('origin') ?? '';
+  const ch = corsHeaders(req, origin);
   const pre = handlePreflight(req, cid);
   if (pre) return pre;
 

--- a/supabase/functions/mapa-testemunhas-processos/index.ts
+++ b/supabase/functions/mapa-testemunhas-processos/index.ts
@@ -9,7 +9,8 @@ import { z } from "npm:zod@3.23.8";
 Deno.serve(async (req) => {
   const cid = req.headers.get("x-correlation-id") ?? crypto.randomUUID();
   const logger = createLogger(cid);
-  const ch = corsHeaders(req);
+  const origin = req.headers.get("origin") ?? "";
+  const ch = corsHeaders(req, origin);
   const pf = handlePreflight(req, cid);
   if (pf) return pf;
 

--- a/supabase/functions/mapa-testemunhas-testemunhas/index.ts
+++ b/supabase/functions/mapa-testemunhas-testemunhas/index.ts
@@ -9,7 +9,8 @@ import { z } from "npm:zod@3.23.8";
 Deno.serve(async (req) => {
   const cid = req.headers.get("x-correlation-id") ?? crypto.randomUUID();
   const logger = createLogger(cid);
-  const ch = corsHeaders(req);
+  const origin = req.headers.get("origin") ?? "";
+  const ch = corsHeaders(req, origin);
   const pf = handlePreflight(req, cid);
   if (pf) return pf;
 


### PR DESCRIPTION
## Summary
- improve shared CORS helper to validate ALLOWED_ORIGINS
- return 204 for OPTIONS and 403 for disallowed origins
- update mapa-* edge functions to use new headers

## Testing
- `npm test` *(fails: vitest not found / npm install 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c17c6819ec8322957ebcbd06e5ecf3