### PR TITLE
fix: clean filters and respect pii on export

### DIFF
--- a/src/components/mapa/ExportCsvButton.tsx
+++ b/src/components/mapa/ExportCsvButton.tsx
@@ -10,7 +10,7 @@ import {
 import { Download, FileSpreadsheet, Loader2 } from "lucide-react";
 import { exportProcessosToCSV, exportTestemunhasToCSV, validateExportSize, estimateCSVSize } from "@/lib/csv";
 import { PorProcesso, PorTestemunha } from "@/types/mapa-testemunhas";
-import { useMapaTestemunhasStore } from "@/lib/store/mapa-testemunhas";
+import { useMapaTestemunhasStore, selectIsPiiMasked } from "@/lib/store/mapa-testemunhas";
 
 // Type aliases for backward compatibility
 type Processo = PorProcesso;
@@ -30,7 +30,7 @@ export const ExportCsvButton = ({
   disabled = false
 }: ExportCsvButtonProps) => {
   const [isExporting, setIsExporting] = useState(false);
-  const isPiiMasked = useMapaTestemunhasStore(s => s.isPiiMasked);
+  const isPiiMasked = useMapaTestemunhasStore(selectIsPiiMasked);
   
   const isProcessoData = (data: ExportData): data is Processo[] => {
     return data.length > 0 && 'cnj' in data[0] && 'reclamante_limpo' in data[0];

--- a/src/lib/store/mapa-testemunhas.ts
+++ b/src/lib/store/mapa-testemunhas.ts
@@ -170,23 +170,27 @@ export const useMapaTestemunhasStore = create<MapaTestemunhasStore>((set, get) =
   setLastUpdate: (date) => set({ lastUpdate: date }),
   setProcessoFilters: (filters) =>
     set((state) => {
-      const merged = { ...state.processoFilters, ...filters } as Record<string, unknown>;
-      const cleaned = Object.fromEntries(
-        Object.entries(merged).filter(([, v]) => v !== undefined)
-      ) as FilterProcesso;
+      const merged = { ...state.processoFilters, ...filters };
+      Object.keys(filters).forEach((k) => {
+        if (filters[k as keyof FilterProcesso] === undefined) {
+          delete (merged as any)[k];
+        }
+      });
       return {
-        processoFilters: cleaned,
+        processoFilters: merged,
         processosPage: 1,
       };
     }),
   setTestemunhaFilters: (filters) =>
     set((state) => {
-      const merged = { ...state.testemunhaFilters, ...filters } as Record<string, unknown>;
-      const cleaned = Object.fromEntries(
-        Object.entries(merged).filter(([, v]) => v !== undefined)
-      ) as FilterTestemunha;
+      const merged = { ...state.testemunhaFilters, ...filters };
+      Object.keys(filters).forEach((k) => {
+        if (filters[k as keyof FilterTestemunha] === undefined) {
+          delete (merged as any)[k];
+        }
+      });
       return {
-        testemunhaFilters: cleaned,
+        testemunhaFilters: merged,
         testemunhasPage: 1,
       };
     }),

--- a/tests/export-csv-mask.test.tsx
+++ b/tests/export-csv-mask.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ExportCsvButton } from '@/components/mapa/ExportCsvButton';
+import { useMapaTestemunhasStore } from '@/lib/store/mapa-testemunhas';
+import {
+  exportProcessosToCSV,
+  exportTestemunhasToCSV,
+  validateExportSize,
+  estimateCSVSize,
+} from '@/lib/csv';
+
+vi.mock('@/lib/csv', () => ({
+  exportProcessosToCSV: vi.fn(() => 1),
+  exportTestemunhasToCSV: vi.fn(() => 1),
+  validateExportSize: vi.fn(() => ({ isValid: true })),
+  estimateCSVSize: vi.fn(() => '1 KB'),
+}));
+
+describe('ExportCsvButton PII masking', () => {
+  beforeEach(() => {
+    useMapaTestemunhasStore.setState({ isPiiMasked: true });
+  });
+
+  it('passes maskPII=true when exporting processos', () => {
+    const data = [{ cnj: '1', reclamante_limpo: 'João' } as any];
+    render(<ExportCsvButton data={data} />);
+    fireEvent.click(screen.getByRole('button', { name: /Exportar dados como CSV/ }));
+    fireEvent.click(screen.getByText('Todos os registros'));
+    expect(exportProcessosToCSV).toHaveBeenCalledWith(expect.any(Array), expect.objectContaining({ maskPII: true }));
+  });
+
+  it('passes maskPII=true when exporting testemunhas', () => {
+    const data = [{ nome_testemunha: 'Ana', cnjs_como_testemunha: [] } as any];
+    render(<ExportCsvButton data={data} />);
+    fireEvent.click(screen.getByRole('button', { name: /Exportar dados como CSV/ }));
+    fireEvent.click(screen.getByText('Todos os registros'));
+    expect(exportTestemunhasToCSV).toHaveBeenCalledWith(expect.any(Array), expect.objectContaining({ maskPII: true }));
+  });
+});

--- a/tests/store-filters.test.ts
+++ b/tests/store-filters.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useMapaTestemunhasStore } from '@/lib/store/mapa-testemunhas';
+
+describe('mapa store filter removal', () => {
+  beforeEach(() => {
+    useMapaTestemunhasStore.setState({ processoFilters: {}, testemunhaFilters: {} });
+  });
+
+  it('removes processo filter when undefined', () => {
+    const { setProcessoFilters } = useMapaTestemunhasStore.getState();
+    setProcessoFilters({ uf: 'SP' } as any);
+    setProcessoFilters({ uf: undefined } as any);
+    expect(useMapaTestemunhasStore.getState().processoFilters.uf).toBeUndefined();
+  });
+
+  it('removes testemunha filter when undefined', () => {
+    const { setTestemunhaFilters } = useMapaTestemunhasStore.getState();
+    setTestemunhaFilters({ nome: 'Ana' } as any);
+    setTestemunhaFilters({ nome: undefined } as any);
+    expect(useMapaTestemunhasStore.getState().testemunhaFilters.nome).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- remove undefined keys when updating filters to avoid stale criteria
- propagate PII mask flag when exporting CSV data
- add tests for filter cleanup and masked exports

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for jose package)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c14ff0a4348322a2573881267c7617