### PR TITLE
refactor: align mapa testemunhas contract and tests

### DIFF
--- a/src/contracts/mapaTestemunhas.ts
+++ b/src/contracts/mapaTestemunhas.ts
@@ -1,41 +1,7 @@
-import { z } from "zod";
+import { ProcessosRequestSchema, type ProcessosRequest } from './mapa-contracts';
 
-const filtersSchema = z
-  .object({
-    uf: z.string().trim().optional(),
-    status: z.string().trim().optional(),
-    fase: z.string().trim().optional(),
-    search: z.string().trim().optional(),
-    testemunha: z.string().trim().optional(),
-    temTriangulacao: z.coerce.boolean().optional(),
-    temTroca: z.coerce.boolean().optional(),
-    jaFoiReclamante: z.coerce.boolean().optional(),
-  })
-  .default({});
-
-export const mapaTestemunhasSchema = z.object({
-  filters: filtersSchema,
-  page: z.coerce.number().int().min(1).default(1),
-  limit: z
-    .coerce.number()
-    .int()
-    .min(1)
-    .default(20)
-    .transform((n) => (n > 200 ? 200 : n)),
-  sortBy: z.string().trim().optional(),
-  sortDir: z.enum(["asc", "desc"]).optional(),
-});
-
-export type MapaTestemunhasRequest = z.infer<typeof mapaTestemunhasSchema>;
+export type MapaTestemunhasRequest = ProcessosRequest;
 
 export function normalizeMapaRequest(payload: unknown): MapaTestemunhasRequest {
-  return mapaTestemunhasSchema.parse(payload);
+  return ProcessosRequestSchema.parse(payload);
 }
-
-export const MapaResponseSchema = z.object({
-  data: z.array(z.unknown()),
-  total: z.number().int(),
-});
-
-export type MapaResponse = z.infer<typeof MapaResponseSchema>;
-

--- a/tests/mapa-contracts.test.ts
+++ b/tests/mapa-contracts.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   ProcessosRequestSchema,
   TestemunhasRequestSchema,
-} from '../supabase/functions/_shared/mapa-contracts';
+} from '../src/contracts/mapa-contracts';
 import { toFieldErrors } from '../supabase/functions/_shared/validation';
 
 describe('ProcessosRequestSchema', () => {

--- a/tests/mapa-testemunhas-endpoints.test.ts
+++ b/tests/mapa-testemunhas-endpoints.test.ts
@@ -18,44 +18,43 @@ function processosEndpoint(payload: unknown): EndpointResponse {
 
 describe('mapa-testemunhas-processos endpoint', () => {
   it('rejects invalid payload', () => {
-    const res = processosEndpoint({ filters: 'invalido', page: 0 })
+    const res = processosEndpoint({ filtros: 'invalido', paginacao: { page: 0 } })
     expect(res.status).toBe(400)
   })
 
   it('normalizes missing page and limit', () => {
-    const res = processosEndpoint({ filters: { temTriangulacao: 'false' } })
+    const res = processosEndpoint({ filtros: { tem_triangulacao: 'false' } })
     expect(res.status).toBe(200)
-    expect(res.body).toMatchObject({ page: 1, limit: 20, filters: { temTriangulacao: false } })
+    expect(res.body).toMatchObject({
+      paginacao: { page: 1, limit: 20 },
+      filtros: { tem_triangulacao: false },
+    })
   })
 
   it('coerces page and limit from strings', () => {
-    const res = processosEndpoint({ page: '2', limit: '50' })
+    const res = processosEndpoint({ paginacao: { page: '2', limit: '50' } })
     expect(res.status).toBe(200)
-    expect(res.body).toMatchObject({ page: 2, limit: 50 })
+    expect(res.body).toMatchObject({ paginacao: { page: 2, limit: 50 }, filtros: {} })
   })
 
   it('trims testemunha filter string', () => {
-    const res = processosEndpoint({ filters: { testemunha: '  Maria  ' } })
+    const res = processosEndpoint({ filtros: { testemunha: '  Maria  ' } })
     expect(res.status).toBe(200)
-    expect(res.body).toMatchObject({ page: 1, limit: 20, filters: { testemunha: 'Maria' } })
+    expect(res.body).toMatchObject({
+      paginacao: { page: 1, limit: 20 },
+      filtros: { testemunha: 'Maria' },
+    })
   })
 
-  it('clamps limit to 200 when above maximum', () => {
-    const res = processosEndpoint({ limit: '999' })
-    expect(res.status).toBe(200)
-    expect(res.body).toMatchObject({ page: 1, limit: 200, filters: {} })
+  it('rejects limit above maximum', () => {
+    const res = processosEndpoint({ paginacao: { limit: '999' } })
+    expect(res.status).toBe(400)
   })
 
   it('handles empty payload using defaults', () => {
     const res = processosEndpoint({})
     expect(res.status).toBe(200)
-    expect(res.body).toMatchObject({ page: 1, limit: 20, filters: {} })
-  })
-
-  it('accepts testemunha filter and trims value', () => {
-    const res = processosEndpoint({ filters: { testemunha: '  João  ' } })
-    expect(res.status).toBe(200)
-    expect(res.body).toMatchObject({ filters: { testemunha: 'João' }, page: 1, limit: 20 })
+    expect(res.body).toMatchObject({ paginacao: { page: 1, limit: 20 }, filtros: {} })
   })
 })
 


### PR DESCRIPTION
## Summary
- use ProcessosRequestSchema for mapa testemunhas normalization
- update tests for paginacao/filtros contract and shared schema

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c181e841508322b3667bb0de1175ec