### PR TITLE
feat: convert filter keys to snake case

### DIFF
--- a/src/components/admin/processos/ProcessosExplorer.tsx
+++ b/src/components/admin/processos/ProcessosExplorer.tsx
@@ -141,14 +141,21 @@ export const ProcessosExplorer = memo(function ProcessosExplorer({ className }: 
       ...(queryParams.uf && queryParams.uf.length > 0 ? { uf: queryParams.uf[0] } : {}),
       ...(queryParams.status && queryParams.status.length > 0 ? { status: queryParams.status[0] } : {}),
       ...(queryParams.fase && queryParams.fase.length > 0 ? { fase: queryParams.fase[0] } : {}),
-      ...(queryParams.flags?.triang ? { tem_triangulacao: true } : {}),
-      ...(queryParams.flags?.troca ? { tem_troca: true } : {}),
-      ...(queryParams.flags?.prova ? { tem_prova_emprestada: true } : {})
+      ...(queryParams.flags?.triang ? { temTriangulacao: true } : {}),
+      ...(queryParams.flags?.troca ? { temTroca: true } : {}),
+      ...(queryParams.flags?.prova ? { temProvaEmprestada: true } : {})
     };
     console.log('🔍 Fetching processos with filters:', apiFilters);
 
+    const specialMap: Record<string, string> = {
+      qtdDeposMin: 'qtd_depoimentos_min',
+      qtdDeposMax: 'qtd_depoimentos_max'
+    };
     const mappedFilters = Object.fromEntries(
-      Object.entries(apiFilters).map(([key, value]) => [key.replace(/[A-Z]/g, m => `_${m.toLowerCase()}`), value])
+      Object.entries(apiFilters).map(([key, value]) => [
+        specialMap[key] ?? key.replace(/[A-Z]/g, m => `_${m.toLowerCase()}`),
+        value
+      ])
     );
 
     const { data: sessionData } = await supabase.auth.getSession();

--- a/src/components/mapa-testemunhas/RiskPanel.tsx
+++ b/src/components/mapa-testemunhas/RiskPanel.tsx
@@ -45,9 +45,9 @@ export const RiskPanel = memo(() => {
 
   // ✅ Callbacks memoizados para filtros
   const filterCallbacks = useMemo(() => ({
-    triangulacao: () => setProcessoFilters({ tem_triangulacao: true }),
-    troca: () => setProcessoFilters({ tem_troca: true }),
-    prova: () => setProcessoFilters({ tem_prova_emprestada: true })
+    triangulacao: () => setProcessoFilters({ temTriangulacao: true }),
+    troca: () => setProcessoFilters({ temTroca: true }),
+    prova: () => setProcessoFilters({ temProvaEmprestada: true })
   }), [setProcessoFilters]);
 
   // ✅ Memoizar configuração dos itens de risco

--- a/src/components/mapa-testemunhas/TestemunhaFilters.tsx
+++ b/src/components/mapa-testemunhas/TestemunhaFilters.tsx
@@ -88,12 +88,12 @@ export function TestemunhaFilters() {
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="tem_triangulacao">Participou Triangulação</Label>
+            <Label htmlFor="temTriangulacao">Participou Triangulação</Label>
             <Select
-              value={testemunhaFilters.tem_triangulacao !== undefined ? testemunhaFilters.tem_triangulacao.toString() : 'TODOS'}
-              onValueChange={(value) => updateFilter('tem_triangulacao', value === 'TODOS' ? undefined : value === 'true')}
+              value={testemunhaFilters.temTriangulacao !== undefined ? testemunhaFilters.temTriangulacao.toString() : 'TODOS'}
+              onValueChange={(value) => updateFilter('temTriangulacao', value === 'TODOS' ? undefined : value === 'true')}
             >
-              <SelectTrigger id="tem_triangulacao">
+              <SelectTrigger id="temTriangulacao">
                 <SelectValue placeholder="Selecione..." />
               </SelectTrigger>
               <SelectContent>
@@ -105,12 +105,12 @@ export function TestemunhaFilters() {
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="tem_troca">Participou Troca</Label>
+            <Label htmlFor="temTroca">Participou Troca</Label>
             <Select
-              value={testemunhaFilters.tem_troca !== undefined ? testemunhaFilters.tem_troca.toString() : 'TODOS'}
-              onValueChange={(value) => updateFilter('tem_troca', value === 'TODOS' ? undefined : value === 'true')}
+              value={testemunhaFilters.temTroca !== undefined ? testemunhaFilters.temTroca.toString() : 'TODOS'}
+              onValueChange={(value) => updateFilter('temTroca', value === 'TODOS' ? undefined : value === 'true')}
             >
-              <SelectTrigger id="tem_troca">
+              <SelectTrigger id="temTroca">
                 <SelectValue placeholder="Selecione..." />
               </SelectTrigger>
               <SelectContent>

--- a/src/components/mapa/RiskPanel.tsx
+++ b/src/components/mapa/RiskPanel.tsx
@@ -44,7 +44,7 @@ export const RiskPanel = () => {
       color: 'text-destructive',
       bgColor: 'bg-destructive/5 hover:bg-destructive/10',
       borderColor: 'border-destructive/20',
-      onClick: () => setProcessoFilters({ tem_triangulacao: true })
+      onClick: () => setProcessoFilters({ temTriangulacao: true })
     },
     {
       id: 'troca',
@@ -56,7 +56,7 @@ export const RiskPanel = () => {
       color: 'text-warning',
       bgColor: 'bg-warning/5 hover:bg-warning/10',
       borderColor: 'border-warning/20',
-      onClick: () => setProcessoFilters({ tem_troca: true })
+      onClick: () => setProcessoFilters({ temTroca: true })
     },
     {
       id: 'prova',
@@ -68,7 +68,7 @@ export const RiskPanel = () => {
       color: 'text-orange-600',
       bgColor: 'bg-orange-50 hover:bg-orange-100 dark:bg-orange-900/10 dark:hover:bg-orange-900/20',
       borderColor: 'border-orange-200 dark:border-orange-900/30',
-      onClick: () => setProcessoFilters({ tem_prova_emprestada: true })
+      onClick: () => setProcessoFilters({ temProvaEmprestada: true })
     }
   ];
 

--- a/src/lib/normalizeMapaRequest.ts
+++ b/src/lib/normalizeMapaRequest.ts
@@ -14,17 +14,17 @@ const ALLOWED_FILTER_KEYS: (keyof KnownFilters)[] = [
   'testemunha',
   'qtdDeposMin',
   'qtdDeposMax',
-  'tem_triangulacao',
-  'tem_troca',
-  'tem_prova_emprestada',
+  'temTriangulacao',
+  'temTroca',
+  'temProvaEmprestada',
   'ambosPolos',
   'jaFoiReclamante'
 ]
 
 const BOOLEAN_FILTER_KEYS = new Set<keyof KnownFilters>([
-  'tem_triangulacao',
-  'tem_troca',
-  'tem_prova_emprestada',
+  'temTriangulacao',
+  'temTroca',
+  'temProvaEmprestada',
   'ambosPolos',
   'jaFoiReclamante'
 ])

--- a/src/lib/store/mapa-testemunhas.test.ts
+++ b/src/lib/store/mapa-testemunhas.test.ts
@@ -18,11 +18,11 @@ describe('mapa-testemunhas store filters', () => {
 
   it('removes testemunha filters when set to undefined', () => {
     const { setTestemunhaFilters } = useMapaTestemunhasStore.getState();
-    setTestemunhaFilters({ search: 'joao', tem_troca: true });
-    expect(useMapaTestemunhasStore.getState().testemunhaFilters).toEqual({ search: 'joao', tem_troca: true });
+    setTestemunhaFilters({ search: 'joao', temTroca: true });
+    expect(useMapaTestemunhasStore.getState().testemunhaFilters).toEqual({ search: 'joao', temTroca: true });
 
-    setTestemunhaFilters({ tem_troca: undefined });
+    setTestemunhaFilters({ temTroca: undefined });
     expect(useMapaTestemunhasStore.getState().testemunhaFilters).toEqual({ search: 'joao' });
-    expect(useMapaTestemunhasStore.getState().testemunhaFilters).not.toHaveProperty('tem_troca');
+    expect(useMapaTestemunhasStore.getState().testemunhaFilters).not.toHaveProperty('temTroca');
   });
 });

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -211,9 +211,9 @@ const mapaRequestSchema = z.object({
       testemunha: z.string().trim().optional(),
       ambosPolos: z.coerce.boolean().optional(),
       jaFoiReclamante: z.coerce.boolean().optional(),
-      tem_triangulacao: z.coerce.boolean().optional(),
-      tem_troca: z.coerce.boolean().optional(),
-      tem_prova_emprestada: z.coerce.boolean().optional(),
+      temTriangulacao: z.coerce.boolean().optional(),
+      temTroca: z.coerce.boolean().optional(),
+      temProvaEmprestada: z.coerce.boolean().optional(),
       qtdDeposMin: z.coerce.number().optional(),
       qtdDeposMax: z.coerce.number().optional(),
     })
@@ -221,11 +221,30 @@ const mapaRequestSchema = z.object({
     .default({}),
 });
 
+function toSnakeCaseFilters(filters?: Record<string, any>) {
+  if (!filters) return filters;
+  const map: Record<string, string> = {
+    temTriangulacao: 'tem_triangulacao',
+    temTroca: 'tem_troca',
+    temProvaEmprestada: 'tem_prova_emprestada',
+    qtdDeposMin: 'qtd_depoimentos_min',
+    qtdDeposMax: 'qtd_depoimentos_max',
+    ambosPolos: 'ambos_polos',
+    jaFoiReclamante: 'ja_foi_reclamante'
+  };
+  return Object.fromEntries(
+    Object.entries(filters).map(([key, value]) => [
+      map[key] ?? key.replace(/[A-Z]/g, m => `_${m.toLowerCase()}`),
+      value
+    ])
+  );
+}
+
 function toEdgePayload<F>(req: MapaTestemunhasRequest<F>) {
   const { page, limit, filters, ...rest } = req;
   return {
     paginacao: { page, limit },
-    filtros: filters,
+    filtros: toSnakeCaseFilters(filters as Record<string, any>),
     ...rest
   };
 }
@@ -346,11 +365,11 @@ export const fetchPorProcesso = async (
       );
     }
 
-    if (parsed.filters.tem_triangulacao) {
+    if (parsed.filters.temTriangulacao) {
       filteredData = filteredData.filter(p => p.triangulacao_confirmada === true);
     }
 
-    if (parsed.filters.tem_prova_emprestada) {
+    if (parsed.filters.temProvaEmprestada) {
       filteredData = filteredData.filter(p => p.contem_prova_emprestada === true);
     }
 
@@ -465,12 +484,12 @@ export const fetchPorTestemunha = async (
       filteredData = filteredData.filter(t => t.ja_foi_reclamante === parsed.filters.jaFoiReclamante);
     }
 
-    if (parsed.filters.tem_triangulacao !== undefined) {
-      filteredData = filteredData.filter(t => t.participou_triangulacao === parsed.filters.tem_triangulacao);
+    if (parsed.filters.temTriangulacao !== undefined) {
+      filteredData = filteredData.filter(t => t.participou_triangulacao === parsed.filters.temTriangulacao);
     }
 
-    if (parsed.filters.tem_troca !== undefined) {
-      filteredData = filteredData.filter(t => t.participou_troca_favor === parsed.filters.tem_troca);
+    if (parsed.filters.temTroca !== undefined) {
+      filteredData = filteredData.filter(t => t.participou_troca_favor === parsed.filters.temTroca);
     }
 
     // Mock pagination

--- a/src/types/mapa-testemunhas.ts
+++ b/src/types/mapa-testemunhas.ts
@@ -63,9 +63,9 @@ export type ProcessoFilters = {
   testemunha?: string;
   qtdDeposMin?: number;
   qtdDeposMax?: number;
-  tem_triangulacao?: boolean;
-  tem_troca?: boolean;
-  tem_prova_emprestada?: boolean;
+  temTriangulacao?: boolean;
+  temTroca?: boolean;
+  temProvaEmprestada?: boolean;
 };
 
 export type TestemunhaFilters = {
@@ -74,8 +74,8 @@ export type TestemunhaFilters = {
   qtdDeposMin?: number;
   qtdDeposMax?: number;
   search?: string;
-  tem_triangulacao?: boolean;
-  tem_troca?: boolean;
+  temTriangulacao?: boolean;
+  temTroca?: boolean;
 };
 
 export type MapaTestemunhasRequest<F = ProcessoFilters | TestemunhaFilters> = {


### PR DESCRIPTION
## Summary
- convert filter names to camelCase internally and snake_case for API
- normalize mapa request filters with camelCase keys
- update components and tests to use new filter names

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jose)*

------
https://chatgpt.com/codex/tasks/task_e_68c19982954c83229133ccff4acd3df4