### PR TITLE
Add demo witness map route with guided tour

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import ResetConfirm from "./pages/ResetConfirm";
 import VerifyOtp from "./pages/VerifyOtp";
 import PortalTitular from "./pages/PortalTitular";
 import NotFound from "./pages/NotFound";
+import DemoMapaTestemunhas from "./pages/DemoMapaTestemunhas";
 
 import Dashboard from "./pages/admin/Dashboard";
 import Analytics from "./pages/admin/Analytics";
@@ -83,6 +84,7 @@ const App = () => (
               <Route path="/verify-otp" element={<VerifyOtp />} />
               <Route path="/portal-titular" element={<PortalTitular />} />
               <Route path="/import/template" element={<TemplatePage />} />
+              <Route path="/demo/mapa-testemunhas" element={<DemoMapaTestemunhas />} />
               
               {/* Protected routes with app layout */}
               <Route path="/*" element={

--- a/src/pages/DemoMapaTestemunhas.tsx
+++ b/src/pages/DemoMapaTestemunhas.tsx
@@ -1,0 +1,135 @@
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from '@/components/ui/table';
+
+interface Witness {
+  nome: string;
+  vinculo: string;
+  risco: 'Alto' | 'Médio' | 'Baixo';
+  prova: 'Sim' | 'Não';
+}
+
+const mockData: Witness[] = [
+  { nome: 'Ana Souza', vinculo: 'Ex-empregada', risco: 'Alto', prova: 'Não' },
+  { nome: 'Bruno Lima', vinculo: 'Colega', risco: 'Médio', prova: 'Sim' },
+  { nome: 'Carla Dias', vinculo: 'Gerente', risco: 'Baixo', prova: 'Sim' },
+  { nome: 'Daniel Rocha', vinculo: 'Fornecedor', risco: 'Médio', prova: 'Não' },
+  { nome: 'Elisa Moreira', vinculo: 'Consultora', risco: 'Alto', prova: 'Sim' },
+];
+
+export default function DemoMapaTestemunhas() {
+  const [step, setStep] = useState(0);
+
+  const next = () => setStep((s) => Math.min(s + 1, 4));
+
+  const riskColor = (risco: Witness['risco']) =>
+    risco === 'Alto' ? 'text-red-600' : risco === 'Médio' ? 'text-yellow-600' : 'text-green-600';
+
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      <h1 className="text-2xl font-bold">Mapa de Testemunhas (Demo)</h1>
+
+      <div className="flex gap-4">
+        <Popover open={step === 0}>
+          <PopoverTrigger asChild>
+            <Button>Novo Mapa</Button>
+          </PopoverTrigger>
+          <PopoverContent>
+            <p>Crie um novo mapa de testemunhas.</p>
+            <Button size="sm" className="mt-2" onClick={next}>
+              Próximo
+            </Button>
+          </PopoverContent>
+        </Popover>
+
+        <Popover open={step === 1}>
+          <PopoverTrigger asChild>
+            <Button variant="outline">Importar do CNJ (mock)</Button>
+          </PopoverTrigger>
+          <PopoverContent>
+            <p>Simule a importação de dados do CNJ.</p>
+            <Button size="sm" className="mt-2" onClick={next}>
+              Próximo
+            </Button>
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      <Popover open={step === 2}>
+        <PopoverTrigger asChild>
+          <div>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Nome</TableHead>
+                  <TableHead>Vínculo</TableHead>
+                  <TableHead>Risco</TableHead>
+                  <TableHead>Prova Emprestada</TableHead>
+                  <TableHead>Ações</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {mockData.map((witness) => (
+                  <TableRow key={witness.nome}>
+                    <TableCell>{witness.nome}</TableCell>
+                    <TableCell>{witness.vinculo}</TableCell>
+                    <TableCell>
+                      <span className={riskColor(witness.risco)}>{witness.risco}</span>
+                    </TableCell>
+                    <TableCell>{witness.prova}</TableCell>
+                    <TableCell>
+                      <Button variant="ghost" size="sm">
+                        Ver
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </PopoverTrigger>
+        <PopoverContent>
+          <p>Revise as testemunhas e seus vínculos.</p>
+          <Button size="sm" className="mt-2" onClick={next}>
+            Próximo
+          </Button>
+        </PopoverContent>
+      </Popover>
+
+      <Popover open={step === 3}>
+        <PopoverTrigger asChild>
+          <div className="h-40 border rounded flex items-center justify-center text-muted-foreground">
+            Mini grafo (placeholder)
+          </div>
+        </PopoverTrigger>
+        <PopoverContent>
+          <p>Visualize as relações no grafo.</p>
+          <Button size="sm" className="mt-2" onClick={next}>
+            Próximo
+          </Button>
+        </PopoverContent>
+      </Popover>
+
+      <Popover open={step === 4}>
+        <PopoverTrigger asChild>
+          <Button>Gerar PDF (mock)</Button>
+        </PopoverTrigger>
+        <PopoverContent>
+          <p>Gere um PDF demonstrativo.</p>
+          <Button size="sm" className="mt-2" asChild>
+            <a href="/beta">Entrar na Beta</a>
+          </Button>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add public `/demo/mapa-testemunhas` route
- prototype witness map page with mock data and 5-step tour
- include final CTA linking to beta signup

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/jose)
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm test` (fails: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c19f001e0c83228dd131f4496835d0