### PR TITLE
feat: add tour reset and popover close handling

### DIFF
--- a/src/pages/DemoMapaTestemunhas.tsx
+++ b/src/pages/DemoMapaTestemunhas.tsx
@@ -30,6 +30,10 @@ export default function DemoMapaTestemunhas() {
 
   const next = () => setStep((s) => Math.min(s + 1, 4));
 
+  const resetTour = () => setStep(0);
+  const handleOpenChange = (currentStep: number) => (open: boolean) =>
+    setStep(open ? currentStep : -1);
+
   const riskColor = (risco: Witness['risco']) =>
     risco === 'Alto' ? 'text-red-600' : risco === 'Médio' ? 'text-yellow-600' : 'text-green-600';
 
@@ -38,7 +42,7 @@ export default function DemoMapaTestemunhas() {
       <h1 className="text-2xl font-bold">Mapa de Testemunhas (Demo)</h1>
 
       <div className="flex gap-4">
-        <Popover open={step === 0}>
+        <Popover open={step === 0} onOpenChange={handleOpenChange(0)}>
           <PopoverTrigger asChild>
             <Button>Novo Mapa</Button>
           </PopoverTrigger>
@@ -50,7 +54,7 @@ export default function DemoMapaTestemunhas() {
           </PopoverContent>
         </Popover>
 
-        <Popover open={step === 1}>
+        <Popover open={step === 1} onOpenChange={handleOpenChange(1)}>
           <PopoverTrigger asChild>
             <Button variant="outline">Importar do CNJ (mock)</Button>
           </PopoverTrigger>
@@ -63,7 +67,7 @@ export default function DemoMapaTestemunhas() {
         </Popover>
       </div>
 
-      <Popover open={step === 2}>
+      <Popover open={step === 2} onOpenChange={handleOpenChange(2)}>
         <PopoverTrigger asChild>
           <div>
             <Table>
@@ -104,7 +108,7 @@ export default function DemoMapaTestemunhas() {
         </PopoverContent>
       </Popover>
 
-      <Popover open={step === 3}>
+      <Popover open={step === 3} onOpenChange={handleOpenChange(3)}>
         <PopoverTrigger asChild>
           <div className="h-40 border rounded flex items-center justify-center text-muted-foreground">
             Mini grafo (placeholder)
@@ -118,7 +122,7 @@ export default function DemoMapaTestemunhas() {
         </PopoverContent>
       </Popover>
 
-      <Popover open={step === 4}>
+      <Popover open={step === 4} onOpenChange={handleOpenChange(4)}>
         <PopoverTrigger asChild>
           <Button>Gerar PDF (mock)</Button>
         </PopoverTrigger>
@@ -126,6 +130,14 @@ export default function DemoMapaTestemunhas() {
           <p>Gere um PDF demonstrativo.</p>
           <Button size="sm" className="mt-2" asChild>
             <a href="/beta">Entrar na Beta</a>
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="mt-2"
+            onClick={resetTour}
+          >
+            Reiniciar
           </Button>
         </PopoverContent>
       </Popover>


### PR DESCRIPTION
## Summary
- add resetTour and handleOpenChange to manage tour state
- allow closing popovers via outside click or ESC
- add Reiniciar button to restart demo tour

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jose)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c1a21649e88322a70d2ffdfd8334a2