### PR TITLE
feat: normalize mapa testemunhas requests to snake_case

### DIFF
--- a/src/types/mapa-testemunhas.ts
+++ b/src/types/mapa-testemunhas.ts
@@ -86,6 +86,47 @@ export type MapaTestemunhasRequest<F = ProcessoFilters | TestemunhaFilters> = {
   filters: F;
 };
 
+// ---------------------------------------------------------------------------
+// API payload types (snake_case)
+// ---------------------------------------------------------------------------
+
+export type ProcessoFiltersApi = {
+  uf?: string;
+  status?: string;
+  fase?: string;
+  search?: string;
+  testemunha?: string;
+  qtd_depoimentos_min?: number;
+  qtd_depoimentos_max?: number;
+  tem_triangulacao?: boolean;
+  tem_troca?: boolean;
+  tem_prova_emprestada?: boolean;
+};
+
+export type TestemunhaFiltersApi = {
+  ambos_polos?: boolean;
+  ja_foi_reclamante?: boolean;
+  qtd_depoimentos_min?: number;
+  qtd_depoimentos_max?: number;
+  search?: string;
+  tem_triangulacao?: boolean;
+  tem_troca?: boolean;
+};
+
+/**
+ * Estrutura enviada ao backend. Utilize `toMapaEdgeRequest` para converter um
+ * {@link MapaTestemunhasRequest} interno (camelCase) para este formato antes de
+ * realizar requisições.
+ */
+export type MapaTestemunhasRequestApi<
+  F = ProcessoFiltersApi | TestemunhaFiltersApi
+> = {
+  paginacao: { page: number; limit: number };
+  sort_by?: string;
+  sort_dir?: 'asc' | 'desc';
+  filtros: F;
+};
+
 export type ImportResult = {
   stagingRows: number;
   upserts: number;


### PR DESCRIPTION
## Summary
- add explicit snake_case API types for mapa testemunhas
- provide toMapaEdgeRequest utility to convert camelCase requests
- ensure supabase fetchers normalize payloads before HTTP calls

## Testing
- `bun run lint` *(fails: eslint: command not found)*
- `bun test` *(fails: Cannot find module '@supabase/supabase-js', Cannot find package 'uuid', Cannot find package 'zod', Cannot find module 'react/jsx-dev-runtime', Cannot find package 'jose', Cannot find package 'zustand', Cannot find package 'papaparse', ENOENT reading "https://deno.land/std@0.168.0/testing/asserts.ts" and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a22bedcc8322906d9a9ac9ca1813