### PR TITLE
feat: centralize CORS middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,30 @@ RATE_LIMIT_WINDOW_MS="60000"
 
 👉 Nunca exponha chaves privadas no repositório. Use `.env.example` para documentação.
 
+### CORS nas Edge Functions
+
+Defina o segredo `ALLOWED_ORIGINS` no projeto Supabase para controlar quais origens podem chamar as Edge Functions:
+
+```
+ALLOWED_ORIGINS="https://assistjur.com.br,https://*.lovable.dev"
+```
+
+Uso no handler:
+
+```ts
+import { parseAllowedOrigins, corsHeaders, handlePreflight } from "../_shared/cors.ts";
+
+const origins = parseAllowedOrigins(Deno.env.get("ALLOWED_ORIGINS"));
+
+Deno.serve(async (req) => {
+  const cid = req.headers.get("x-correlation-id") ?? crypto.randomUUID();
+  const ch = corsHeaders(req, origins);
+  const pf = handlePreflight(req, origins, { "x-correlation-id": cid });
+  if (pf) return pf;
+  // ...
+});
+```
+
 ### 4. Rodar em modo dev
 
 ```bash

--- a/supabase/functions/import-mapa-testemunhas/index.ts
+++ b/supabase/functions/import-mapa-testemunhas/index.ts
@@ -1,10 +1,12 @@
 import { createClient } from "npm:@supabase/supabase-js@2.56.0";
-import { corsHeaders, handlePreflight } from "../_shared/cors.ts";
+import { corsHeaders, handlePreflight, parseAllowedOrigins } from "../_shared/cors.ts";
+
+const origins = parseAllowedOrigins(Deno.env.get('ALLOWED_ORIGINS'));
 
 Deno.serve(async (req) => {
   const cid = req.headers.get('x-correlation-id') ?? crypto.randomUUID();
-  const ch = corsHeaders(req);
-  const pre = handlePreflight(req, cid);
+  const ch = corsHeaders(req, origins);
+  const pre = handlePreflight(req, origins, { 'x-correlation-id': cid });
   if (pre) return pre;
 
   try {

--- a/supabase/functions/manage-user-roles/index.ts
+++ b/supabase/functions/manage-user-roles/index.ts
@@ -1,5 +1,5 @@
 import { createClient } from "npm:@supabase/supabase-js@2.56.0";
-import { corsHeaders, handlePreflight } from "../_shared/cors.ts";
+import { corsHeaders, handlePreflight, parseAllowedOrigins } from "../_shared/cors.ts";
 
 const supabase = createClient(
   Deno.env.get('SUPABASE_URL') ?? '',
@@ -13,10 +13,12 @@ interface ManageUserRequest {
   data_access_level?: 'FULL' | 'MASKED' | 'NONE';
 }
 
+const origins = parseAllowedOrigins(Deno.env.get('ALLOWED_ORIGINS'));
+
 const handler = async (req: Request): Promise<Response> => {
   const cid = req.headers.get('x-correlation-id') ?? crypto.randomUUID();
-  const ch = corsHeaders(req);
-  const pre = handlePreflight(req, cid);
+  const ch = corsHeaders(req, origins);
+  const pre = handlePreflight(req, origins, { 'x-correlation-id': cid });
   if (pre) return pre;
 
   try {

--- a/supabase/functions/mapa-testemunhas-analysis/index.ts
+++ b/supabase/functions/mapa-testemunhas-analysis/index.ts
@@ -1,5 +1,5 @@
 import { createClient } from 'npm:@supabase/supabase-js@2.56.0'
-import { corsHeaders, handlePreflight } from '../_shared/cors.ts'
+import { corsHeaders, handlePreflight, parseAllowedOrigins } from '../_shared/cors.ts'
 
 // Types for analysis results
 interface AnalysisResult {
@@ -69,11 +69,12 @@ interface PadroesAgregados {
   concentracao_uf: { [key: string]: number }
 }
 
+const origins = parseAllowedOrigins(Deno.env.get('ALLOWED_ORIGINS'));
+
 Deno.serve(async (req) => {
   const cid = req.headers.get('x-correlation-id') ?? crypto.randomUUID();
-  const origin = req.headers.get('origin') ?? '';
-  const ch = corsHeaders(req, origin);
-  const pre = handlePreflight(req, cid);
+  const ch = corsHeaders(req, origins);
+  const pre = handlePreflight(req, origins, { 'x-correlation-id': cid });
   if (pre) return pre;
 
   try {

--- a/supabase/functions/mapa-testemunhas-processos/index.ts
+++ b/supabase/functions/mapa-testemunhas-processos/index.ts
@@ -1,17 +1,18 @@
 import { createClient } from "npm:@supabase/supabase-js@2.56.0";
-import { corsHeaders, handlePreflight } from "../_shared/cors.ts";
+import { corsHeaders, handlePreflight, parseAllowedOrigins } from "../_shared/cors.ts";
 import { createLogger } from "../_shared/logger.ts";
 import { ListaResponseSchema, ProcessosRequestSchema } from "../_shared/mapa-contracts.ts";
 import { applyProcessosFilters } from "../_shared/mapa-filters.ts";
 import { json, jsonError } from "../_shared/http.ts";
 import { toFieldErrors } from "../_shared/validation.ts";
 
+const origins = parseAllowedOrigins(Deno.env.get("ALLOWED_ORIGINS"));
+
 Deno.serve(async (req) => {
   const cid = req.headers.get("x-correlation-id") ?? crypto.randomUUID();
   const logger = createLogger(cid);
-  const origin = req.headers.get("origin") ?? "";
-  const ch = corsHeaders(req, origin);
-  const pf = handlePreflight(req, cid);
+  const ch = corsHeaders(req, origins);
+  const pf = handlePreflight(req, origins, { "x-correlation-id": cid });
   if (pf) return pf;
 
   let payload: unknown = {};

--- a/supabase/functions/mapa-testemunhas-testemunhas/index.ts
+++ b/supabase/functions/mapa-testemunhas-testemunhas/index.ts
@@ -1,17 +1,18 @@
 import { createClient } from "npm:@supabase/supabase-js@2.56.0";
-import { corsHeaders, handlePreflight } from "../_shared/cors.ts";
+import { corsHeaders, handlePreflight, parseAllowedOrigins } from "../_shared/cors.ts";
 import { createLogger } from "../_shared/logger.ts";
 import { ListaResponseSchema, TestemunhasRequestSchema } from "../_shared/mapa-contracts.ts";
 import { applyTestemunhasFilters } from "../_shared/mapa-filters.ts";
 import { json, jsonError } from "../_shared/http.ts";
 import { toFieldErrors } from "../_shared/validation.ts";
 
+const origins = parseAllowedOrigins(Deno.env.get("ALLOWED_ORIGINS"));
+
 Deno.serve(async (req) => {
   const cid = req.headers.get("x-correlation-id") ?? crypto.randomUUID();
   const logger = createLogger(cid);
-  const origin = req.headers.get("origin") ?? "";
-  const ch = corsHeaders(req, origin);
-  const pf = handlePreflight(req, cid);
+  const ch = corsHeaders(req, origins);
+  const pf = handlePreflight(req, origins, { "x-correlation-id": cid });
   if (pf) return pf;
 
   let payload: unknown = {};

--- a/supabase/functions/user-invitations/index.ts
+++ b/supabase/functions/user-invitations/index.ts
@@ -1,5 +1,5 @@
 import { createClient } from "npm:@supabase/supabase-js@2.56.0";
-import { corsHeaders, handlePreflight } from "../_shared/cors.ts";
+import { corsHeaders, handlePreflight, parseAllowedOrigins } from "../_shared/cors.ts";
 import { json, jsonError } from "../_shared/http.ts";
 import { z } from "npm:zod@3.23.8";
 
@@ -8,10 +8,12 @@ const supabase = createClient(
   Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
 );
 
+const origins = parseAllowedOrigins(Deno.env.get('ALLOWED_ORIGINS'));
+
 const handler = async (req: Request): Promise<Response> => {
   const cid = req.headers.get('x-correlation-id') ?? crypto.randomUUID();
-  const ch = corsHeaders(req);
-  const pf = handlePreflight(req, cid);
+  const ch = corsHeaders(req, origins);
+  const pf = handlePreflight(req, origins, { 'x-correlation-id': cid });
   if (pf) return pf;
 
   try {

--- a/supabase/tests/cors.test.ts
+++ b/supabase/tests/cors.test.ts
@@ -1,0 +1,53 @@
+import {
+  corsHeaders,
+  handlePreflight,
+  parseAllowedOrigins,
+} from "../functions/_shared/cors.ts";
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+
+const origins = parseAllowedOrigins("https://a.com,https://*.b.com");
+
+Deno.test("allows listed origin", () => {
+  const req = new Request("http://localhost", {
+    headers: { origin: "https://a.com" },
+  });
+  const headers = corsHeaders(req, origins);
+  assertEquals(headers["Access-Control-Allow-Origin"], "https://a.com");
+});
+
+Deno.test("blocks unlisted origin", () => {
+  const req = new Request("http://localhost", {
+    headers: { origin: "https://evil.com" },
+  });
+  const res = handlePreflight(req, origins);
+  assert(res);
+  assertEquals(res!.status, 403);
+});
+
+Deno.test("preflight returns CORS headers", () => {
+  const req = new Request("http://localhost", {
+    method: "OPTIONS",
+    headers: {
+      origin: "https://a.com",
+      "Access-Control-Request-Headers": "authorization,apikey",
+    },
+  });
+  const res = handlePreflight(req, origins) as Response;
+  assertEquals(res.status, 204);
+  assertEquals(res.headers.get("Access-Control-Allow-Origin"), "https://a.com");
+  assertEquals(res.headers.get("Access-Control-Allow-Headers"), "authorization,apikey");
+});
+
+Deno.test("authorization and apikey headers exposed", () => {
+  const req = new Request("http://localhost", {
+    headers: { origin: "https://a.com" },
+  });
+  const headers = corsHeaders(req, origins);
+  const allow = headers["Access-Control-Allow-Headers"] ?? "";
+  assert(allow.includes("authorization"));
+  assert(allow.includes("apikey"));
+});
+


### PR DESCRIPTION
## Summary
- centralize CORS handling and expose helpers
- apply CORS middleware to auth and mapa functions
- document ALLOWED_ORIGINS secret and usage
- add unit tests for CORS middleware

## Testing
- `deno test -A supabase/tests/cors.test.ts supabase/tests/security_demo.test.ts` *(fails: command not found)*
- `curl -fsSL https://deno.land/install.sh | sh` *(fails: 403 Forbidden)*
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bf48d82483229275ffbbebb35c4b