### PR TITLE
feat: add session context and risk handling

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1347,6 +1347,36 @@ export type Database = {
         }
         Relationships: []
       }
+      sessions: {
+        Row: {
+          created_at: string | null
+          device_label: string | null
+          id: string
+          last_ip: unknown | null
+          last_seen: string | null
+          risk_score: number | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          device_label?: string | null
+          id?: string
+          last_ip?: unknown | null
+          last_seen?: string | null
+          risk_score?: number | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          device_label?: string | null
+          id?: string
+          last_ip?: unknown | null
+          last_seen?: string | null
+          risk_score?: number | null
+          user_id?: string
+        }
+        Relationships: []
+      }
       user_sessions: {
         Row: {
           created_at: string | null

--- a/src/pages/ResetConfirm.tsx
+++ b/src/pages/ResetConfirm.tsx
@@ -105,6 +105,8 @@ const ResetConfirm = () => {
         throw error;
       }
 
+      await supabase.auth.refreshSession();
+
       toast.success("Senha atualizada!", {
         description: "Sua senha foi redefinida com sucesso. Faça login com a nova senha."
       });

--- a/src/security/sessionContext.ts
+++ b/src/security/sessionContext.ts
@@ -1,0 +1,21 @@
+export interface SessionContext {
+  userAgent: string;
+  timezone: string;
+  language: string;
+  platform: string;
+}
+
+/**
+ * Collects a lightweight fingerprint of the current environment
+ * including user agent, timezone, language and platform hints.
+ */
+export function getSessionContext(): SessionContext {
+  const nav = typeof navigator !== 'undefined' ? navigator : undefined;
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return {
+    userAgent: nav?.userAgent || 'unknown',
+    timezone: timezone || 'UTC',
+    language: nav?.language || 'unknown',
+    platform: (nav as any)?.userAgentData?.platform || nav?.platform || 'unknown',
+  };
+}

--- a/src/security/sessionService.ts
+++ b/src/security/sessionService.ts
@@ -1,0 +1,67 @@
+import { getSessionContext } from './sessionContext';
+
+export interface SessionRecord {
+  id?: string;
+  user_id: string;
+  device_label?: string | null;
+  last_ip?: string | null;
+  last_seen?: string | null;
+  risk_score?: number | null;
+}
+
+const SUSPICIOUS_ASN_PATTERNS = ['tor', 'vpn'];
+
+export function calculateRiskScore(current: { last_ip?: string | null; timezone: string; hour?: number }, history: SessionRecord[]): number {
+  let score = 0;
+  const ip = current.last_ip;
+  if (ip && !history.some((s) => s.last_ip === ip)) {
+    score += 50; // new location
+  }
+  if (ip && SUSPICIOUS_ASN_PATTERNS.some((p) => ip.includes(p))) {
+    score += 30; // suspicious ASN placeholder
+  }
+  const hour = current.hour ?? new Date().getHours();
+  if (hour < 6 || hour > 22) {
+    score += 20; // unusual hours
+  }
+  return score;
+}
+
+/**
+ * Records a session entry and returns the calculated risk score.
+ * If risk is high the caller should require step-up authentication.
+ */
+export async function recordSession(userId: string, ip?: string | null) {
+  const { supabase } = await import('@/integrations/supabase/client');
+  const ctx = getSessionContext();
+  const { data: previous } = await supabase
+    .from('sessions')
+    .select('last_ip')
+    .eq('user_id', userId);
+  const history = (previous as SessionRecord[]) || [];
+  const risk = calculateRiskScore({ last_ip: ip, timezone: ctx.timezone }, history);
+  await supabase.from('sessions').insert({
+    user_id: userId,
+    device_label: ctx.platform,
+    last_ip: ip,
+    risk_score: risk,
+  });
+  if (risk >= 70) {
+    await supabase.from('audit_logs').insert({
+      user_id: userId,
+      action: 'session_anomaly',
+      result: 'RISK',
+      ip_address: ip,
+      user_agent: ctx.userAgent,
+      metadata: { risk },
+    } as any);
+  }
+  return risk;
+}
+
+export async function terminateSession(sessionId: string) {
+  const { supabase } = await import('@/integrations/supabase/client');
+  await supabase.functions.invoke('end-sessions', {
+    body: { session_id: sessionId },
+  });
+}

--- a/supabase/functions/end-sessions/index.ts
+++ b/supabase/functions/end-sessions/index.ts
@@ -1,0 +1,32 @@
+import { corsHeaders, validateJWT, createSecureErrorResponse, createAuthenticatedClient } from "../_shared/security.ts";
+
+export async function handler(req: Request): Promise<Response> {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  const token = req.headers.get("authorization")?.replace("Bearer ", "") ?? "";
+  if (!(await validateJWT(token))) {
+    return createSecureErrorResponse("unauthorized", 401);
+  }
+
+  let body: { session_id?: string } = {};
+  try {
+    body = await req.json();
+  } catch {
+    return createSecureErrorResponse("invalid_body", 400);
+  }
+  if (!body.session_id) {
+    return createSecureErrorResponse("missing_session", 400);
+  }
+
+  const client = createAuthenticatedClient(token);
+  const { error } = await client.from("sessions").delete().match({ id: body.session_id });
+  if (error) {
+    return createSecureErrorResponse("delete_failed", 400);
+  }
+
+  return new Response(JSON.stringify({ success: true }), { headers: corsHeaders });
+}
+
+Deno.serve(handler);

--- a/supabase/migrations/20250911120000_add_sessions_table.sql
+++ b/supabase/migrations/20250911120000_add_sessions_table.sql
@@ -1,0 +1,21 @@
+-- Create sessions table for contextual logins
+create table if not exists public.sessions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  device_label text,
+  last_ip inet,
+  last_seen timestamptz default now(),
+  risk_score integer default 0,
+  created_at timestamptz default now()
+);
+
+alter table public.sessions enable row level security;
+
+create policy "Users can view own sessions" on public.sessions
+  for select using (auth.uid() = user_id);
+
+create policy "Users can delete own sessions" on public.sessions
+  for delete using (auth.uid() = user_id);
+
+create policy "Users can update own sessions" on public.sessions
+  for update using (auth.uid() = user_id);

--- a/supabase/tests/end_sessions.test.ts
+++ b/supabase/tests/end_sessions.test.ts
@@ -1,0 +1,17 @@
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
+
+const { handler } = await import("../functions/end-sessions/index.ts");
+
+const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+const payload = btoa(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 60 }));
+const validJWT = `${header}.${payload}.sig`;
+
+Deno.test("CORS preflight", async () => {
+  const res = await handler(new Request("http://localhost", { method: "OPTIONS" }));
+  assertEquals(res.status, 200);
+});
+
+Deno.test("rejects invalid jwt", async () => {
+  const res = await handler(new Request("http://localhost", { method: "POST", body: "{}" }));
+  assertEquals(res.status, 401);
+});

--- a/tests/sessionContext.test.ts
+++ b/tests/sessionContext.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { getSessionContext } from '@/security/sessionContext';
+import { calculateRiskScore } from '@/security/sessionService';
+
+describe('session context', () => {
+  it('collects basic fingerprint', () => {
+    const ctx = getSessionContext();
+    expect(ctx).toHaveProperty('userAgent');
+    expect(ctx).toHaveProperty('timezone');
+    expect(ctx).toHaveProperty('language');
+  });
+
+  it('calculates risk score for new ip and unusual hour', () => {
+    const score = calculateRiskScore({ last_ip: '1.1.1.1', timezone: 'UTC', hour: 2 }, []);
+    expect(score).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- collect lightweight fingerprint via `sessionContext`
- log sessions with risk score and audit anomalies
- add endpoint to terminate sessions

## Testing
- `npm test` *(fails: vitest not found)*
- `deno test supabase/tests/end_sessions.test.ts` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c6dfde548322bc9dc46d3e47142a