### PR TITLE
feat: implement LGPD consent and retention workflow

### DIFF
--- a/README-lgpd.md
+++ b/README-lgpd.md
@@ -1,0 +1,17 @@
+# LGPD Consent and Legal Basis
+
+This document summarizes the legal bases used for collecting and processing personal data within the project.
+
+## Legal Bases
+- **Analytics**: Consent of the data subject (art. 7, I).
+- **Marketing**: Consent of the data subject (art. 7, I).
+- **Data Sharing**: Legitimate interest or specific consent depending on partner (art. 7, IX).
+
+## Retention
+The `lgpd_consent` table stores the retention period in days for each user. An automated job removes or anonymizes data once the period expires.
+
+## Reversibility & Auditability
+Users may change their consent at any time. All changes are recorded in `lgpd_consent_history` for audit purposes.
+
+## Logs
+Application logs are minimized and avoid storing personally identifiable information.

--- a/scripts/export-consent.js
+++ b/scripts/export-consent.js
@@ -1,0 +1,26 @@
+import { createClient } from '@supabase/supabase-js';
+import fs from 'fs';
+import Papa from 'papaparse';
+
+const supabaseUrl = process.env.SUPABASE_URL ?? '';
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+async function run(format = 'json') {
+  const { data, error } = await supabase.from('lgpd_consent').select('*');
+  if (error) throw error;
+  if (format === 'csv') {
+    const csv = Papa.unparse(data || []);
+    fs.writeFileSync('lgpd_consent.csv', csv);
+    console.log('exported lgpd_consent.csv');
+  } else {
+    fs.writeFileSync('lgpd_consent.json', JSON.stringify(data, null, 2));
+    console.log('exported lgpd_consent.json');
+  }
+}
+
+const fmt = process.argv[2] === 'csv' ? 'csv' : 'json';
+run(fmt).catch(e => {
+  console.error('export error', e);
+  process.exit(1);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import ConsentBanner from "@/components/ConsentBanner";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { AuthProvider } from "@/hooks/useAuth";
@@ -67,6 +68,7 @@ const App = () => (
         <TooltipProvider>
           <Toaster />
           <Sonner />
+          <ConsentBanner />
           <BrowserRouter
             future={{
               v7_startTransition: true,

--- a/src/components/ConsentBanner.tsx
+++ b/src/components/ConsentBanner.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { useLGPDConsent } from '@/hooks/useLGPDConsent';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+
+export const ConsentBanner = () => {
+  const { consent, saveConsent, loading } = useLGPDConsent();
+  const [analytics, setAnalytics] = useState(true);
+  const [marketing, setMarketing] = useState(false);
+  const [sharing, setSharing] = useState(false);
+
+  if (loading || consent) return null;
+
+  const submit = async () => {
+    await saveConsent({
+      analytics,
+      marketing,
+      sharing,
+      retention_period_days: 365,
+      legal_basis: 'consent'
+    });
+  };
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 bg-white shadow p-4">
+      <p className="mb-2">Este site usa dados para analytics e marketing. Ajuste suas preferências:</p>
+      <div className="flex gap-4 mb-2">
+        <label className="flex items-center gap-2">
+          <Switch checked={analytics} onCheckedChange={setAnalytics} /> Analytics
+        </label>
+        <label className="flex items-center gap-2">
+          <Switch checked={marketing} onCheckedChange={setMarketing} /> Marketing
+        </label>
+        <label className="flex items-center gap-2">
+          <Switch checked={sharing} onCheckedChange={setSharing} /> Compartilhar dados
+        </label>
+      </div>
+      <Button onClick={submit}>Salvar preferências</Button>
+    </div>
+  );
+};
+
+export default ConsentBanner;

--- a/src/hooks/useLGPDConsent.ts
+++ b/src/hooks/useLGPDConsent.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+
+export interface LGPDConsent {
+  analytics: boolean;
+  marketing: boolean;
+  sharing: boolean;
+  retention_period_days: number;
+  legal_basis: string;
+}
+
+export function useLGPDConsent() {
+  const [consent, setConsent] = useState<LGPDConsent | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) {
+        setLoading(false);
+        return;
+      }
+      const { data } = await supabase
+        .from('lgpd_consent')
+        .select('analytics, marketing, sharing, retention_period_days, legal_basis')
+        .eq('user_id', user.id)
+        .single();
+      if (data) setConsent(data as LGPDConsent);
+      setLoading(false);
+    }
+    load();
+  }, []);
+
+  const saveConsent = async (c: LGPDConsent) => {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return;
+    await supabase.from('lgpd_consent').upsert({ user_id: user.id, ...c, updated_at: new Date().toISOString() });
+    setConsent(c);
+  };
+
+  return { consent, saveConsent, loading };
+}

--- a/src/middleware/consent.ts
+++ b/src/middleware/consent.ts
@@ -1,0 +1,13 @@
+import { supabase } from '@/integrations/supabase/client';
+
+/** Check if current user allowed analytics */
+export const analyticsAllowed = async (): Promise<boolean> => {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return false;
+  const { data } = await supabase
+    .from('lgpd_consent')
+    .select('analytics')
+    .eq('user_id', user.id)
+    .single();
+  return !!data?.analytics;
+};

--- a/src/pages/admin/Analytics.tsx
+++ b/src/pages/admin/Analytics.tsx
@@ -19,6 +19,7 @@ import {
   CheckCircle
 } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
+import { analyticsAllowed } from '@/middleware/consent';
 import { toast } from 'sonner';
 import { 
   UsageChart, 
@@ -52,6 +53,7 @@ const Analytics = () => {
   const [patternsData, setPatternsData] = useState<any>(null);
 
   const fetchDetailedAnalytics = async (period: string) => {
+    if (!(await analyticsAllowed())) return;
     setLoading(true);
     try {
       const { data, error } = await supabase.functions.invoke('admin-analytics', {
@@ -72,6 +74,7 @@ const Analytics = () => {
   };
 
   const fetchUsageData = async () => {
+    if (!(await analyticsAllowed())) return;
     try {
       const { data, error } = await supabase.functions.invoke('admin-analytics', {
         body: { type: 'usage', period: selectedPeriod }
@@ -84,6 +87,7 @@ const Analytics = () => {
   };
 
   const fetchPatternsData = async () => {
+    if (!(await analyticsAllowed())) return;
     try {
       const { data, error } = await supabase.functions.invoke('admin-analytics', {
         body: { type: 'ai_patterns' }
@@ -96,6 +100,7 @@ const Analytics = () => {
   };
 
   const exportReport = async (format: 'pdf' | 'excel') => {
+    if (!(await analyticsAllowed())) return;
     setExportLoading(true);
     try {
       const { data, error } = await supabase.functions.invoke('admin-analytics', {

--- a/supabase/functions/lgpd-retention/index.ts
+++ b/supabase/functions/lgpd-retention/index.ts
@@ -1,0 +1,38 @@
+import 'https://deno.land/x/xhr@0.1.0/mod.ts';
+import { createClient } from 'npm:@supabase/supabase-js@2.56.0';
+import { corsHeaders, handlePreflight } from '../_shared/cors.ts';
+
+Deno.serve(async (req) => {
+  const cid = req.headers.get('x-correlation-id') ?? crypto.randomUUID();
+  const pre = handlePreflight(req, cid);
+  if (pre) return pre;
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  );
+
+  try {
+    const { data } = await supabase.from('lgpd_consent').select('*');
+    const now = new Date();
+    let processed = 0;
+    for (const row of data ?? []) {
+      const expiry = new Date(row.updated_at);
+      expiry.setDate(expiry.getDate() + (row.retention_period_days || 0));
+      if (expiry < now) {
+        await supabase.from('profiles').update({ full_name: null }).eq('user_id', row.user_id);
+        await supabase.from('lgpd_consent').delete().eq('user_id', row.user_id);
+        processed++;
+      }
+    }
+    return new Response(JSON.stringify({ processed }), {
+      headers: { ...corsHeaders(req), 'x-correlation-id': cid, 'content-type': 'application/json' }
+    });
+  } catch (error) {
+    console.error('lgpd-retention error', error);
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { ...corsHeaders(req), 'x-correlation-id': cid, 'content-type': 'application/json' }
+    });
+  }
+});

--- a/supabase/migrations/20250912000000_lgpd_consent.sql
+++ b/supabase/migrations/20250912000000_lgpd_consent.sql
@@ -1,0 +1,34 @@
+-- Create table for storing LGPD consent with audit trail
+create table if not exists public.lgpd_consent (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  analytics boolean default false,
+  marketing boolean default false,
+  sharing boolean default false,
+  retention_period_days integer default 365,
+  legal_basis text not null,
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+-- History table for auditing changes
+create table if not exists public.lgpd_consent_history (
+  id bigserial primary key,
+  user_id uuid references auth.users(id) on delete cascade,
+  analytics boolean,
+  marketing boolean,
+  sharing boolean,
+  retention_period_days integer,
+  legal_basis text,
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create or replace function public.log_lgpd_consent_changes() returns trigger as $$
+begin
+  insert into public.lgpd_consent_history(user_id, analytics, marketing, sharing, retention_period_days, legal_basis, updated_at)
+  values(old.user_id, old.analytics, old.marketing, old.sharing, old.retention_period_days, old.legal_basis, old.updated_at);
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger lgpd_consent_audit
+after update or delete on public.lgpd_consent
+for each row execute function public.log_lgpd_consent_changes();


### PR DESCRIPTION
## Summary
- add `lgpd_consent` table and audit trail
- show consent banner and hook into analytics checks
- schedule edge function for data retention and add export script

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c1c6efc6e88322baff4366f73432bb