### PR TITLE
feat: add audit logging with pii masking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,7 +126,7 @@ const App = () => (
           <Route path="/admin/compliance" element={<Compliance />} />
           <Route path="/admin/marketing" element={<MarketingCompliance />} />
                          <Route path="/admin/retencao" element={<DataRetention />} />
-                         <Route path="/admin/auditoria" element={<AuditPanel />} />
+                         <Route path="/admin/audit" element={<AuditPanel />} />
                          <Route path="/admin/config" element={<SystemConfig />} />
                         <Route path="/relatorio" element={<ReportDemo />} />
                         

--- a/src/components/admin/processos/ExportManager.tsx
+++ b/src/components/admin/processos/ExportManager.tsx
@@ -27,7 +27,7 @@ import {
 import { ProcessoRow, ProcessoQuery, ExportFormat, ExportOptions } from '@/types/processos-explorer';
 import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/integrations/supabase/client';
+import { logAudit } from '@/lib/audit';
 
 interface ExportManagerProps {
   open: boolean;
@@ -75,16 +75,11 @@ export function ExportManager({
       }, 100);
 
       // Log audit entry
-      console.log('🎯 Logging export action...');
-      await supabase.from('audit_logs').insert({
-        user_id: user.id,
-        email: user.email,
-        role: profile.role,
-        organization_id: profile.organization_id,
-        action: 'EXPORT_PROCESSOS',
-        resource: 'processos',
-        result: 'SUCCESS',
-        metadata: {
+      await logAudit(
+        'EXPORT_PROCESSOS',
+        'processos',
+        null,
+        {
           format: exportOptions.format,
           records_count: exportCount,
           filters_applied: filters,
@@ -92,7 +87,7 @@ export function ExportManager({
           selected_only: exportOptions.selectedOnly,
           include_filters: exportOptions.includeFilters
         }
-      });
+      );
 
       // Generate export based on format
       let fileName = '';

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,0 +1,20 @@
+import { supabase } from '@/integrations/supabase/client';
+import { applyPIIMask } from '@/utils/pii-mask';
+
+export async function logAudit(
+  action: string,
+  entity: string,
+  entityId: string | null,
+  fields: Record<string, any> = {}
+) {
+  const masked = applyPIIMask(fields, true);
+  const { error } = await supabase.rpc('log_audit', {
+    p_action: action,
+    p_entity: entity,
+    p_entity_id: entityId,
+    p_fields_masked: masked
+  });
+  if (error) {
+    console.error('logAudit error', error);
+  }
+}

--- a/supabase/migrations/20251015120000_audit_logging.sql
+++ b/supabase/migrations/20251015120000_audit_logging.sql
@@ -1,0 +1,78 @@
+-- Audit logging infrastructure
+-- Adds required fields and functions for secure audit logging
+
+-- 1. Rename existing columns to match new schema
+ALTER TABLE public.audit_logs RENAME COLUMN resource TO entity;
+ALTER TABLE public.audit_logs RENAME COLUMN metadata TO fields_masked;
+ALTER TABLE public.audit_logs RENAME COLUMN ip_address TO ip;
+ALTER TABLE public.audit_logs RENAME COLUMN user_agent TO ua;
+ALTER TABLE public.audit_logs ADD COLUMN IF NOT EXISTS entity_id uuid;
+
+-- 2. Helper function to mask email addresses
+CREATE OR REPLACE FUNCTION public.mask_email(email text)
+RETURNS text AS $$
+BEGIN
+  IF email IS NULL THEN
+    RETURN NULL;
+  END IF;
+  RETURN concat(left(email, 1), '****', substring(email from position('@' in email)));
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- 3. Function to log audit events
+CREATE OR REPLACE FUNCTION public.log_audit(p_action text, p_entity text, p_entity_id uuid, p_fields_masked jsonb)
+RETURNS void AS $$
+DECLARE
+  v_claims json;
+  v_tenant uuid;
+  v_user uuid;
+  v_ip text;
+  v_ua text;
+  v_fields jsonb := p_fields_masked;
+BEGIN
+  v_claims := current_setting('request.jwt.claims', true)::json;
+  v_tenant := (v_claims->>'tenant_id')::uuid;
+  v_user := auth.uid();
+  v_ip := current_setting('request.headers', true)::json->>'x-forwarded-for';
+  v_ua := current_setting('request.headers', true)::json->>'user-agent';
+
+  IF v_fields ? 'email' THEN
+    v_fields := jsonb_set(v_fields, '{email}', to_jsonb(mask_email(v_fields->>'email')), true);
+  END IF;
+
+  INSERT INTO audit_logs (tenant_id, user_id, action, entity, entity_id, fields_masked, ip, ua)
+  VALUES (v_tenant, v_user, p_action, p_entity, p_entity_id, v_fields, v_ip, v_ua);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 4. Trigger: log permission changes on profiles
+CREATE OR REPLACE FUNCTION public.audit_profile_role_change()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.role IS DISTINCT FROM OLD.role THEN
+    PERFORM log_audit('UPDATE_PERMISSION', TG_TABLE_NAME, NEW.id, jsonb_build_object('old_role', OLD.role, 'new_role', NEW.role));
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS trg_audit_profile_role_change ON public.profiles;
+CREATE TRIGGER trg_audit_profile_role_change
+AFTER UPDATE ON public.profiles
+FOR EACH ROW
+EXECUTE FUNCTION public.audit_profile_role_change();
+
+-- 5. Trigger: log deletions on processos
+CREATE OR REPLACE FUNCTION public.audit_processos_delete()
+RETURNS trigger AS $$
+BEGIN
+  PERFORM log_audit('DELETE', TG_TABLE_NAME, OLD.id, NULL);
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS trg_audit_processos_delete ON public.processos;
+CREATE TRIGGER trg_audit_processos_delete
+AFTER DELETE ON public.processos
+FOR EACH ROW
+EXECUTE FUNCTION public.audit_processos_delete();

--- a/tests/admin-audit-page.test.tsx
+++ b/tests/admin-audit-page.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import AuditPanel from '@/pages/admin/AuditPanel';
+
+const auditLogs = [
+  {
+    id: '1',
+    user_id: 'u1',
+    action: 'EXPORT_PROCESSOS',
+    entity: 'processos',
+    created_at: new Date().toISOString(),
+    profiles: { email: 'user1@example.com' }
+  },
+  {
+    id: '2',
+    user_id: 'u2',
+    action: 'DELETE',
+    entity: 'processos',
+    created_at: new Date().toISOString(),
+    profiles: { email: 'user2@example.com' }
+  }
+];
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (table: string) => ({
+      select: () => ({
+        gte: () => ({
+          order: () => ({
+            limit: async () => {
+              if (table === 'audit_logs') return { data: auditLogs, error: null };
+              return { data: [], error: null };
+            }
+          })
+        })
+      })
+    })
+  }
+}));
+
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ user: { id: 'u1' } }) }));
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+describe('AuditPanel filters', () => {
+  it('filters by user email', async () => {
+    render(<AuditPanel />);
+    await waitFor(() => screen.getByText('Painel de Auditoria'));
+    const input = screen.getByPlaceholderText('Filtrar por usuário');
+    fireEvent.change(input, { target: { value: 'user2' } });
+    expect(await screen.findByText('DELETE')).toBeInTheDocument();
+    expect(screen.queryByText('EXPORT_PROCESSOS')).toBeNull();
+  });
+});

--- a/tests/log-audit.test.ts
+++ b/tests/log-audit.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { logAudit } from '@/lib/audit';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    rpc: vi.fn().mockResolvedValue({ error: null })
+  }
+}));
+
+vi.mock('@/utils/pii-mask', () => ({
+  applyPIIMask: (data: any) => ({ ...data, email: 'te***@example.com' })
+}));
+
+describe('logAudit', () => {
+  it('masks PII fields before logging', async () => {
+    const { supabase } = await import('@/integrations/supabase/client');
+    await logAudit('TEST', 'entity', '123', { email: 'test@example.com' });
+    expect(supabase.rpc).toHaveBeenCalledWith('log_audit', {
+      p_action: 'TEST',
+      p_entity: 'entity',
+      p_entity_id: '123',
+      p_fields_masked: { email: 'te***@example.com' }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add server-side `log_audit` function with email masking and triggers for permission updates and deletions
- create `logAudit` helper and use it in export actions
- enhance admin audit panel with action and user filters and route `/admin/audit`

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c1c700cf8883228f5af70f85211763