### PR TITLE
Improve auth error feedback and signup redirect

### DIFF
--- a/src/components/auth/EmailPasswordForm.tsx
+++ b/src/components/auth/EmailPasswordForm.tsx
@@ -87,7 +87,7 @@ export const EmailPasswordForm = ({
     } catch (error: any) {
       console.error('Login error:', error);
       toast.error("Erro no login", {
-        description: "Não foi possível entrar. Verifique suas credenciais."
+        description: error?.message || "Não foi possível entrar. Verifique suas credenciais."
       });
     } finally {
       setIsLoading(false);
@@ -119,7 +119,7 @@ export const EmailPasswordForm = ({
     } catch (error: any) {
       console.error('Signup error:', error);
       toast.error("Erro no cadastro", {
-        description: "Não foi possível criar a conta. Verifique os dados e tente novamente.",
+        description: error?.message || "Não foi possível criar a conta. Verifique os dados e tente novamente.",
       });
     } finally {
       setIsLoading(false);

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -201,6 +201,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         if (error.message.includes('Invalid login credentials')) {
           return { error: { message: 'E-mail ou senha incorretos.' } };
         }
+
+        if (error.message.includes('Email not confirmed')) {
+          return { error: { message: 'E-mail não confirmado. Verifique sua caixa de entrada.' } };
+        }
+
         return { error };
       }
 
@@ -302,7 +307,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const signUp = async (email: string, password: string, name?: string, orgCode?: string) => {
     try {
       setLoading(true);
-      const redirectUrl = `${window.location.origin}/`;
+      // Redirect users back to the login page with a confirmation flag
+      // so the UI can display the proper message after e-mail verification.
+      const redirectUrl = `${window.location.origin}/login?confirm=1`;
 
       const { data, error } = await supabase.auth.signUp({
         email,
@@ -315,6 +322,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
       if (error) {
         await logAuthAttempt(email, 'signup', 'failure', { error: error.message });
+        if (error.message.includes('User already registered')) {
+          return { error: { message: 'E-mail já cadastrado. Faça login.' } };
+        }
         return { error };
       }
 


### PR DESCRIPTION
## Summary
- redirect email confirmations to `/login?confirm=1`
- return friendly errors for unconfirmed logins and existing emails
- surface auth error messages in login/signup forms

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c1ddff627c8322b09fba57771086b4