### PR TITLE
feat: improve mobile navigation and card browsing

### DIFF
--- a/src/components/site/AgentsPreview.tsx
+++ b/src/components/site/AgentsPreview.tsx
@@ -1,8 +1,18 @@
 import React from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle
+} from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Sparkles, Database, Search, BarChart3, Brain } from 'lucide-react';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselApi
+} from '@/components/ui/carousel';
 
 export function AgentsPreview() {
   const agents = [
@@ -43,6 +53,19 @@ export function AgentsPreview() {
     },
   ];
 
+  const [api, setApi] = React.useState<CarouselApi>();
+  const [current, setCurrent] = React.useState(0);
+
+  React.useEffect(() => {
+    if (!api) return;
+    const onSelect = () => setCurrent(api.selectedScrollSnap());
+    onSelect();
+    api.on('select', onSelect);
+    return () => {
+      api.off('select', onSelect);
+    };
+  }, [api]);
+
   return (
     <section className="py-20 bg-muted/20">
       <div className="container mx-auto px-6">
@@ -57,16 +80,73 @@ export function AgentsPreview() {
             </p>
           </div>
 
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8 mb-12">
+          {/* Mobile Carousel */}
+          <div className="md:hidden mb-12">
+            <Carousel setApi={setApi} opts={{ align: 'start' }} className="-mx-6">
+              <CarouselContent>
+                {agents.map((agent, index) => (
+                  <CarouselItem key={index} className="pl-6">
+                    <Card className="relative border-border/50 hover:shadow-lg transition-all duration-300 group overflow-hidden">
+                      {/* Status Badge */}
+                      <div className="absolute top-4 right-4 z-10">
+                        <Badge
+                          variant="secondary"
+                          className={`font-medium ${agent.statusColor}`}
+                        >
+                          {agent.status}
+                        </Badge>
+                      </div>
+
+                      <CardHeader className="text-center pb-4">
+                        <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-gradient-card border border-border/50 flex items-center justify-center group-hover:scale-110 transition-transform">
+                          <agent.icon className="h-8 w-8 text-primary" />
+                        </div>
+                        <CardTitle className="text-lg text-foreground leading-tight">
+                          {agent.title}
+                        </CardTitle>
+                      </CardHeader>
+
+                      <CardContent className="text-center">
+                        <p className="text-muted-foreground text-sm leading-relaxed">
+                          {agent.description}
+                        </p>
+                      </CardContent>
+                    </Card>
+                  </CarouselItem>
+                ))}
+              </CarouselContent>
+            </Carousel>
+            <div className="flex justify-center mt-4 gap-2">
+              {agents.map((_, index) => (
+                <button
+                  key={index}
+                  onClick={() => api?.scrollTo(index)}
+                  className="p-4"
+                  aria-label={`Ir para agente ${index + 1}`}
+                >
+                  <span
+                    className={`block w-3 h-3 rounded-full ${
+                      current === index
+                        ? 'bg-primary'
+                        : 'bg-muted-foreground/20'
+                    }`}
+                  />
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Desktop Grid */}
+          <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-3 gap-8 mb-12">
             {agents.map((agent, index) => (
-              <Card 
+              <Card
                 key={index}
                 className="relative border-border/50 hover:shadow-lg transition-all duration-300 group overflow-hidden"
               >
                 {/* Status Badge */}
                 <div className="absolute top-4 right-4 z-10">
-                  <Badge 
-                    variant="secondary" 
+                  <Badge
+                    variant="secondary"
                     className={`font-medium ${agent.statusColor}`}
                   >
                     {agent.status}
@@ -81,7 +161,7 @@ export function AgentsPreview() {
                     {agent.title}
                   </CardTitle>
                 </CardHeader>
-                
+
                 <CardContent className="text-center">
                   <p className="text-muted-foreground text-sm leading-relaxed">
                     {agent.description}

--- a/src/components/site/PublicHeader.tsx
+++ b/src/components/site/PublicHeader.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
-import { Menu, X } from 'lucide-react';
+import { Menu, X, ChevronDown } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { BRAND } from '@/branding/brand';
 
@@ -33,15 +33,30 @@ export function PublicHeader({ onBetaClick }: PublicHeaderProps) {
     setIsMobileMenuOpen(false);
   };
 
-  const navItems = [
+  type NavItem = {
+    label: string;
+    action?: () => void;
+    children?: { label: string; action: () => void }[];
+  };
+
+  const navItems: NavItem[] = [
     { label: 'Início', action: () => scrollToSection('hero') },
     { label: 'Para Quem', action: () => scrollToSection('publico') },
     { label: 'Diferenciais', action: () => scrollToSection('diferenciais') },
     { label: 'ROI', action: () => scrollToSection('roi') },
     { label: 'Agentes', action: () => scrollToSection('agentes') },
     { label: 'Segurança', action: () => scrollToSection('seguranca') },
-    { label: 'Sobre', action: () => navigate('/sobre') }
+    {
+      label: 'Sobre',
+      action: () => scrollToSection('sobre'),
+      children: [
+        { label: 'O AssistJur.IA', action: () => scrollToSection('sobre') },
+        { label: 'Bianca Reinstein', action: () => scrollToSection('bianca') }
+      ]
+    }
   ];
+
+  const [openSubmenu, setOpenSubmenu] = useState<number | null>(null);
 
   return (
     <header className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
@@ -114,18 +129,46 @@ export function PublicHeader({ onBetaClick }: PublicHeaderProps) {
             <div className="px-6 py-6 space-y-4">
               {/* Mobile Navigation Items */}
               {navItems.map((item, index) => (
-                <button
-                  key={index}
-                  onClick={item.action}
-                  className="block w-full text-left px-4 py-3 text-foreground/80 hover:text-primary hover:bg-muted/50 rounded-lg transition-all duration-200 font-medium"
-                >
-                  {item.label}
-                </button>
+                <div key={index}>
+                  <button
+                    onClick={() => {
+                      if (item.children) {
+                        setOpenSubmenu(openSubmenu === index ? null : index);
+                      } else {
+                        item.action?.();
+                      }
+                    }}
+                    className="flex w-full items-center justify-between text-left px-4 py-4 text-foreground/80 hover:text-primary hover:bg-muted/50 rounded-lg transition-all duration-200 font-medium"
+                  >
+                    {item.label}
+                    {item.children && (
+                      <ChevronDown
+                        className={`h-4 w-4 transition-transform ${openSubmenu === index ? 'rotate-180' : ''}`}
+                      />
+                    )}
+                  </button>
+                  {item.children && openSubmenu === index && (
+                    <div className="pl-4">
+                      {item.children.map((child, cIndex) => (
+                        <button
+                          key={cIndex}
+                          onClick={() => {
+                            child.action();
+                            setIsMobileMenuOpen(false);
+                          }}
+                          className="block w-full text-left px-4 py-4 text-foreground/70 hover:text-primary hover:bg-muted/50 rounded-lg transition-all duration-200"
+                        >
+                          {child.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
               ))}
-              
+
               {/* Mobile Action Buttons */}
               <div className="pt-4 space-y-3 border-t border-border/20">
-                <Button 
+                <Button
                   onClick={() => {
                     navigate('/login');
                     setIsMobileMenuOpen(false);
@@ -135,7 +178,7 @@ export function PublicHeader({ onBetaClick }: PublicHeaderProps) {
                 >
                   Login
                 </Button>
-                <Button 
+                <Button
                   onClick={() => {
                     navigate('/beta');
                     setIsMobileMenuOpen(false);

--- a/src/components/site/ValueProps.tsx
+++ b/src/components/site/ValueProps.tsx
@@ -1,8 +1,56 @@
 import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { CheckCircle, ArrowRight, Target, TrendingUp, Shield, Award, Users, Brain } from 'lucide-react';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselApi
+} from '@/components/ui/carousel';
 
 export function ValueProps() {
+  const [diffApi, setDiffApi] = React.useState<CarouselApi>();
+  const [diffCurrent, setDiffCurrent] = React.useState(0);
+
+  React.useEffect(() => {
+    if (!diffApi) return;
+    const onSelect = () => setDiffCurrent(diffApi.selectedScrollSnap());
+    onSelect();
+    diffApi.on('select', onSelect);
+    return () => diffApi.off('select', onSelect);
+  }, [diffApi]);
+
+  const diferentials = [
+    {
+      icon: Brain,
+      iconBg: 'bg-primary/20',
+      iconColor: 'text-primary',
+      title: 'Especialização Jurídica',
+      text: 'Desenvolvido por especialistas com mais de 20 anos de experiência em gestão de contencioso.'
+    },
+    {
+      icon: Award,
+      iconBg: 'bg-accent/20',
+      iconColor: 'text-accent',
+      title: 'Conhecimento de Jurisprudência',
+      text: 'Estrutura pensado para interpretar dados jurídicos, decisões e padrões processuais.'
+    },
+    {
+      icon: TrendingUp,
+      iconBg: 'bg-success/20',
+      iconColor: 'text-success',
+      title: 'Integração com Bases Jurídicas',
+      text: 'Capacidade de cruzar dados internos da empresa com informações de tribunais e sistemas públicos.'
+    },
+    {
+      icon: Shield,
+      iconBg: 'bg-primary/20',
+      iconColor: 'text-primary',
+      title: 'Supervisão Especializada',
+      text: 'Outputs sempre validados por advogados — tecnologia que apoia, mas não substitui a análise humana.'
+    }
+  ];
+
   return (
     <section id="diferenciais" className="py-20 bg-muted/20">
       <div className="container mx-auto px-6">
@@ -188,79 +236,78 @@ export function ValueProps() {
             <h3 className="text-2xl font-bold text-center text-foreground">
               Nossos Diferenciais
             </h3>
-            
-            <div className="grid md:grid-cols-2 gap-6">
-              <Card className="border-border/50 hover:border-primary/50 hover:shadow-lg transition-all duration-300">
-                <CardContent className="p-6">
-                  <div className="flex items-start space-x-4">
-                    <div className="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center flex-shrink-0">
-                      <Brain className="h-5 w-5 text-primary" />
-                    </div>
-                    <div>
-                      <h4 className="text-lg font-semibold mb-2 text-foreground">
-                        Especialização Jurídica
-                      </h4>
-                      <p className="text-muted-foreground text-sm">
-                        Desenvolvido por especialistas com mais de 20 anos de experiência em gestão de contencioso.
-                      </p>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
 
-              <Card className="border-border/50 hover:border-primary/50 hover:shadow-lg transition-all duration-300">
-                <CardContent className="p-6">
-                  <div className="flex items-start space-x-4">
-                    <div className="w-10 h-10 rounded-full bg-accent/20 flex items-center justify-center flex-shrink-0">
-                      <Award className="h-5 w-5 text-accent" />
-                    </div>
-                    <div>
-                      <h4 className="text-lg font-semibold mb-2 text-foreground">
-                        Conhecimento de Jurisprudência
-                      </h4>
-                      <p className="text-muted-foreground text-sm">
-                        Estrutura pensado para interpretar dados jurídicos, decisões e padrões processuais.
-                      </p>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
+            {/* Mobile Carousel */}
+            <div className="md:hidden">
+              <Carousel setApi={setDiffApi} opts={{ align: 'start' }} className="-mx-6">
+                <CarouselContent>
+                  {diferentials.map((diff, index) => (
+                    <CarouselItem key={index} className="pl-6">
+                      <Card className="border-border/50 hover:border-primary/50 hover:shadow-lg transition-all duration-300">
+                        <CardContent className="p-6">
+                          <div className="flex items-start space-x-4">
+                            <div className={`w-10 h-10 rounded-full ${diff.iconBg} flex items-center justify-center flex-shrink-0`}>
+                              <diff.icon className={`h-5 w-5 ${diff.iconColor}`} />
+                            </div>
+                            <div>
+                              <h4 className="text-lg font-semibold mb-2 text-foreground">
+                                {diff.title}
+                              </h4>
+                              <p className="text-muted-foreground text-sm">
+                                {diff.text}
+                              </p>
+                            </div>
+                          </div>
+                        </CardContent>
+                      </Card>
+                    </CarouselItem>
+                  ))}
+                </CarouselContent>
+              </Carousel>
+              <div className="flex justify-center mt-4 gap-2">
+                {diferentials.map((_, index) => (
+                  <button
+                    key={index}
+                    onClick={() => diffApi?.scrollTo(index)}
+                    className="p-4"
+                    aria-label={`Ir para diferencial ${index + 1}`}
+                  >
+                    <span
+                      className={`block w-3 h-3 rounded-full ${
+                        diffCurrent === index
+                          ? 'bg-primary'
+                          : 'bg-muted-foreground/20'
+                      }`}
+                    />
+                  </button>
+                ))}
+              </div>
+            </div>
 
-              <Card className="border-border/50 hover:border-primary/50 hover:shadow-lg transition-all duration-300">
-                <CardContent className="p-6">
-                  <div className="flex items-start space-x-4">
-                    <div className="w-10 h-10 rounded-full bg-success/20 flex items-center justify-center flex-shrink-0">
-                      <TrendingUp className="h-5 w-5 text-success" />
+            {/* Desktop Grid */}
+            <div className="hidden md:grid md:grid-cols-2 gap-6">
+              {diferentials.map((diff, index) => (
+                <Card
+                  key={index}
+                  className="border-border/50 hover:border-primary/50 hover:shadow-lg transition-all duration-300"
+                >
+                  <CardContent className="p-6">
+                    <div className="flex items-start space-x-4">
+                      <div className={`w-10 h-10 rounded-full ${diff.iconBg} flex items-center justify-center flex-shrink-0`}>
+                        <diff.icon className={`h-5 w-5 ${diff.iconColor}`} />
+                      </div>
+                      <div>
+                        <h4 className="text-lg font-semibold mb-2 text-foreground">
+                          {diff.title}
+                        </h4>
+                        <p className="text-muted-foreground text-sm">
+                          {diff.text}
+                        </p>
+                      </div>
                     </div>
-                    <div>
-                      <h4 className="text-lg font-semibold mb-2 text-foreground">
-                        Integração com Bases Jurídicas
-                      </h4>
-                      <p className="text-muted-foreground text-sm">
-                        Capacidade de cruzar dados internos da empresa com informações de tribunais e sistemas públicos.
-                      </p>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card className="border-border/50 hover:border-primary/50 hover:shadow-lg transition-all duration-300">
-                <CardContent className="p-6">
-                  <div className="flex items-start space-x-4">
-                    <div className="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center flex-shrink-0">
-                      <Shield className="h-5 w-5 text-primary" />
-                    </div>
-                    <div>
-                      <h4 className="text-lg font-semibold mb-2 text-foreground">
-                        Supervisão Especializada
-                      </h4>
-                      <p className="text-muted-foreground text-sm">
-                        Outputs sempre validados por advogados — tecnologia que apoia, mas não substitui a análise humana.
-                      </p>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
+                  </CardContent>
+                </Card>
+              ))}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- turn agent and differential grids into swipeable carousels with indicators
- switch mobile navigation to a hamburger menu with expandable sub-items

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for @testing-library/dom)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c1e28d06088322a3635aa2a2b57d6d