### PR TITLE
feat(auth): support remember me option for sign in

### DIFF
--- a/src/components/auth/EmailPasswordForm.tsx
+++ b/src/components/auth/EmailPasswordForm.tsx
@@ -72,7 +72,8 @@ export const EmailPasswordForm = ({
     setIsLoading(true);
 
     try {
-      const { error } = await signIn(data.email, data.password, 'OFFICE');
+      // Passa o valor de "Lembrar-me" para controlar a persistência da sessão
+      const { error } = await signIn(data.email, data.password, 'OFFICE', data.rememberMe);
 
       if (error) {
         throw error;

--- a/tests/demoMapaTestemunhas.test.tsx
+++ b/tests/demoMapaTestemunhas.test.tsx
@@ -14,6 +14,7 @@ vi.mock('@/hooks/useAuth', () => ({
     profile: null,
     session: null,
     loading: false,
+    // signIn(email, password, role, rememberMe?, orgCode?)
     signIn: vi.fn(),
     signUp: vi.fn(),
     signOut: vi.fn(),


### PR DESCRIPTION
## Summary
- pass `rememberMe` from email/password form to `signIn`
- allow `signIn` to control session persistence via Supabase
- document new `signIn` parameters in interface and tests

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c1e35d5d508322b3417e26f6f9188d