### PR TITLE
feat: add accessible back-to-top FAB

### DIFF
--- a/src/components/site/BackToTopFAB.tsx
+++ b/src/components/site/BackToTopFAB.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { ArrowUp } from 'lucide-react';
+
+export function BackToTopFAB() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 600);
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    const heading = document.getElementById('main-heading');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    if (heading) {
+      setTimeout(() => heading.focus(), 500);
+    }
+  };
+
+  if (!visible) return null;
+
+  return (
+    <Button
+      size="icon"
+      aria-label="Voltar ao topo"
+      className="fixed bottom-6 right-6 rounded-full shadow-lg z-50"
+      onClick={scrollToTop}
+    >
+      <ArrowUp className="h-5 w-5" />
+    </Button>
+  );
+}

--- a/src/components/site/ImprovedHero.tsx
+++ b/src/components/site/ImprovedHero.tsx
@@ -49,7 +49,11 @@ export function ImprovedHero({ onSignup }: ImprovedHeroProps) {
 
             {/* Main Headline */}
             <div className="space-y-4">
-              <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-foreground leading-tight">
+              <h1
+                id="main-heading"
+                tabIndex={-1}
+                className="text-4xl md:text-5xl lg:text-6xl font-bold text-foreground leading-tight"
+              >
                 AssistJur.IA —{' '}
                 <span className="relative">
                   <span className="text-primary">

--- a/src/pages/PublicHome.tsx
+++ b/src/pages/PublicHome.tsx
@@ -11,6 +11,7 @@ import { AboutBianca } from '@/components/site/AboutBianca';
 import { Footer } from '@/components/site/Footer';
 import { BetaModal } from '@/components/sobre/BetaModal';
 import { Toaster } from '@/components/ui/toaster';
+import { BackToTopFAB } from '@/components/site/BackToTopFAB';
 
 export default function PublicHome() {
   const [isBetaModalOpen, setIsBetaModalOpen] = useState(false);
@@ -86,6 +87,8 @@ export default function PublicHome() {
 
       {/* Toast notifications */}
       <Toaster />
+
+      <BackToTopFAB />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add floating 'Voltar ao topo' button appearing after scrolling and focusing main heading
- make top heading focusable for screen reader after scroll
- integrate FAB into public home page

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c1e566a498832293c2e4ce33bbbae8