### PR TITLE
feat: enable lazy routes and defer images

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Suspense, lazy } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -11,44 +11,44 @@ import AuthGuard from "@/components/AuthGuard";
 import { AppLayout } from "@/components/navigation/AppLayout";
 import { ErrorBoundary } from "@/components/core/ErrorBoundary";
 
-import MapaPage from "./pages/MapaPage";
-import PublicHome from "./pages/PublicHome";
-import About from "./pages/About";
-import Beta from "./pages/Beta";
-import Login from "./pages/Login";
-import Reset from "./pages/Reset";
-import ResetConfirm from "./pages/ResetConfirm";
-import VerifyOtp from "./pages/VerifyOtp";
-import PortalTitular from "./pages/PortalTitular";
-import NotFound from "./pages/NotFound";
-import DemoMapaTestemunhas from "./pages/DemoMapaTestemunhas";
+const MapaPage = lazy(() => import("./pages/MapaPage"));
+const PublicHome = lazy(() => import("./pages/PublicHome"));
+const About = lazy(() => import("./pages/About"));
+const Beta = lazy(() => import("./pages/Beta"));
+const Login = lazy(() => import("./pages/Login"));
+const Reset = lazy(() => import("./pages/Reset"));
+const ResetConfirm = lazy(() => import("./pages/ResetConfirm"));
+const VerifyOtp = lazy(() => import("./pages/VerifyOtp"));
+const PortalTitular = lazy(() => import("./pages/PortalTitular"));
+const NotFound = lazy(() => import("./pages/NotFound"));
+const DemoMapaTestemunhas = lazy(() => import("./pages/DemoMapaTestemunhas"));
 
-import Dashboard from "./pages/admin/Dashboard";
-import Analytics from "./pages/admin/Analytics";
-import ImportBase from "./pages/admin/ImportBase";
-import TemplatePage from "./pages/TemplatePage";
-import Versions from "./pages/admin/Versions";
-import Organization from "./pages/admin/Organization";
+const Dashboard = lazy(() => import("./pages/admin/Dashboard"));
+const Analytics = lazy(() => import("./pages/admin/Analytics"));
+const ImportBase = lazy(() => import("./pages/admin/ImportBase"));
+const TemplatePage = lazy(() => import("./pages/TemplatePage"));
+const Versions = lazy(() => import("./pages/admin/Versions"));
+const Organization = lazy(() => import("./pages/admin/Organization"));
 
-import SystemConfig from "./pages/admin/SystemConfig";
-import Compliance from "./pages/admin/Compliance";
-import MarketingCompliance from "./pages/admin/MarketingCompliance";
-import DataRetention from "./pages/admin/DataRetention";
-import AuditPanel from "./pages/admin/AuditPanel";
-import OpenAI from "./pages/admin/OpenAI";
-import OpenAIKeys from "./pages/admin/openai/Keys";
-import OpenAIModels from "./pages/admin/openai/Models";
-import PromptStudio from "./pages/admin/openai/PromptStudio";
-import OpenAIPlayground from "./pages/admin/openai/Playground";
-import Logs from "./pages/admin/Logs";
-import { ReportDemo } from "./pages/ReportDemo";
-import ValidationTest from "./pages/admin/ValidationTest";
+const SystemConfig = lazy(() => import("./pages/admin/SystemConfig"));
+const Compliance = lazy(() => import("./pages/admin/Compliance"));
+const MarketingCompliance = lazy(() => import("./pages/admin/MarketingCompliance"));
+const DataRetention = lazy(() => import("./pages/admin/DataRetention"));
+const AuditPanel = lazy(() => import("./pages/admin/AuditPanel"));
+const OpenAI = lazy(() => import("./pages/admin/OpenAI"));
+const OpenAIKeys = lazy(() => import("./pages/admin/openai/Keys"));
+const OpenAIModels = lazy(() => import("./pages/admin/openai/Models"));
+const PromptStudio = lazy(() => import("./pages/admin/openai/PromptStudio"));
+const OpenAIPlayground = lazy(() => import("./pages/admin/openai/Playground"));
+const Logs = lazy(() => import("./pages/admin/Logs"));
+const ReportDemo = lazy(() => import("./pages/ReportDemo"));
+const ValidationTest = lazy(() => import("./pages/admin/ValidationTest"));
 
 // Data Explorer components
-import BaseRedirect from "./pages/admin/base/index";
-import BaseLayout from "./pages/admin/base/BaseLayout";
-import ProcessosTable from "./pages/admin/base/ProcessosTable";
-import TestemunhasTable from "./pages/admin/base/TestemunhasTable";
+const BaseRedirect = lazy(() => import("./pages/admin/base/index"));
+const BaseLayout = lazy(() => import("./pages/admin/base/BaseLayout"));
+const ProcessosTable = lazy(() => import("./pages/admin/base/ProcessosTable"));
+const TestemunhasTable = lazy(() => import("./pages/admin/base/TestemunhasTable"));
 
 
 // Analytics component import and routes
@@ -72,74 +72,81 @@ const App = () => (
           <ConsentProvider>
             <ConsentDialog />
             <BrowserRouter
-            future={{
-              v7_startTransition: true,
-              v7_relativeSplatPath: true,
-            }}
-          >
-            <Routes>
-              {/* Public routes */}
-              <Route path="/" element={<PublicHome />} />
-              <Route path="/sobre" element={<About />} />
-              <Route path="/beta" element={<Beta />} />
-              <Route path="/login" element={<Login />} />
-              <Route path="/reset" element={<Reset />} />
-              <Route path="/reset/confirm" element={<ResetConfirm />} />
-              <Route path="/verify-otp" element={<VerifyOtp />} />
-              <Route path="/portal-titular" element={<PortalTitular />} />
-              <Route path="/import/template" element={<TemplatePage />} />
-              <Route path="/demo/mapa-testemunhas" element={<DemoMapaTestemunhas />} />
-              
-              {/* Protected routes with app layout */}
-              <Route path="/*" element={
-                <AuthGuard>
-                  <AppLayout>
-                    <ErrorBoundary>
-                      <Routes>
-                        <Route path="/dashboard" element={<Navigate to="/mapa" replace />} />
-                        <Route path="/mapa" element={<MapaPage />} />
-                        <Route path="/mapa-testemunhas" element={<MapaPage />} />
-                        <Route path="/dados" element={<Navigate to="/mapa" replace />} />
-                        <Route path="/dados/mapa" element={<Navigate to="/mapa" replace />} />
-                         {/* Redirect deprecated chat route to mapa-testemunhas */}
-                         <Route path="/chat" element={<Navigate to="/mapa-testemunhas?view=chat" replace />} />
-                        <Route path="/app/chat" element={<Navigate to="/mapa-testemunhas?view=chat" replace />} />
-                        
-                        {/* Admin routes */}
-                        <Route path="/admin" element={<Dashboard />} />
-                        <Route path="/admin/analytics" element={<Analytics />} />
-                        <Route path="/admin/ia" element={<OpenAI />} />
-                        <Route path="/admin/ia/chaves" element={<OpenAIKeys />} />
-                        <Route path="/admin/ia/modelos" element={<OpenAIModels />} />
-                        <Route path="/admin/ia/prompt-studio" element={<PromptStudio />} />
-                        <Route path="/admin/ia/testes" element={<OpenAIPlayground />} />
-                        <Route path="/admin/base-import" element={<ImportBase />} />
-                        <Route path="/admin/base-import/test" element={<ValidationTest />} />
-                        <Route path="/admin/base" element={<BaseRedirect />} />
-                        <Route path="/admin/base/*" element={<BaseLayout />}>
-                          <Route path="processos" element={<ProcessosTable />} />
-                          <Route path="testemunhas" element={<TestemunhasTable />} />
-                        </Route>
-                        <Route path="/import" element={<Navigate to="/admin/base-import" replace />} />
-                        <Route path="/admin/versoes" element={<Versions />} />
-                        <Route path="/admin/org" element={<Organization />} />
-                        <Route path="/admin/organization" element={<Organization />} />
-                         <Route path="/admin/logs" element={<Logs />} />
-          <Route path="/admin/compliance" element={<Compliance />} />
-          <Route path="/admin/marketing" element={<MarketingCompliance />} />
-                         <Route path="/admin/retencao" element={<DataRetention />} />
-                         <Route path="/admin/audit" element={<AuditPanel />} />
-                         <Route path="/admin/config" element={<SystemConfig />} />
-                        <Route path="/relatorio" element={<ReportDemo />} />
-                        
-                        <Route path="*" element={<NotFound />} />
-                      </Routes>
-                    </ErrorBoundary>
-                  </AppLayout>
-                </AuthGuard>
-              } />
-            </Routes>
-          </BrowserRouter>
+              future={{
+                v7_startTransition: true,
+                v7_relativeSplatPath: true,
+              }}
+            >
+              <Suspense fallback={<div className="p-4">Carregando...</div>}>
+                <Routes>
+                  {/* Public routes */}
+                  <Route path="/" element={<PublicHome />} />
+                  <Route path="/sobre" element={<About />} />
+                  <Route path="/beta" element={<Beta />} />
+                  <Route path="/login" element={<Login />} />
+                  <Route path="/reset" element={<Reset />} />
+                  <Route path="/reset/confirm" element={<ResetConfirm />} />
+                  <Route path="/verify-otp" element={<VerifyOtp />} />
+                  <Route path="/portal-titular" element={<PortalTitular />} />
+                  <Route path="/import/template" element={<TemplatePage />} />
+                  <Route path="/demo/mapa-testemunhas" element={<DemoMapaTestemunhas />} />
+
+                  {/* Protected routes with app layout */}
+                  <Route
+                    path="/*"
+                    element={
+                      <AuthGuard>
+                        <AppLayout>
+                          <ErrorBoundary>
+                            <Suspense fallback={<div className="p-4">Carregando...</div>}>
+                              <Routes>
+                                <Route path="/dashboard" element={<Navigate to="/mapa" replace />} />
+                                <Route path="/mapa" element={<MapaPage />} />
+                                <Route path="/mapa-testemunhas" element={<MapaPage />} />
+                                <Route path="/dados" element={<Navigate to="/mapa" replace />} />
+                                <Route path="/dados/mapa" element={<Navigate to="/mapa" replace />} />
+                                {/* Redirect deprecated chat route to mapa-testemunhas */}
+                                <Route path="/chat" element={<Navigate to="/mapa-testemunhas?view=chat" replace />} />
+                                <Route path="/app/chat" element={<Navigate to="/mapa-testemunhas?view=chat" replace />} />
+
+                                {/* Admin routes */}
+                                <Route path="/admin" element={<Dashboard />} />
+                                <Route path="/admin/analytics" element={<Analytics />} />
+                                <Route path="/admin/ia" element={<OpenAI />} />
+                                <Route path="/admin/ia/chaves" element={<OpenAIKeys />} />
+                                <Route path="/admin/ia/modelos" element={<OpenAIModels />} />
+                                <Route path="/admin/ia/prompt-studio" element={<PromptStudio />} />
+                                <Route path="/admin/ia/testes" element={<OpenAIPlayground />} />
+                                <Route path="/admin/base-import" element={<ImportBase />} />
+                                <Route path="/admin/base-import/test" element={<ValidationTest />} />
+                                <Route path="/admin/base" element={<BaseRedirect />} />
+                                <Route path="/admin/base/*" element={<BaseLayout />}>
+                                  <Route path="processos" element={<ProcessosTable />} />
+                                  <Route path="testemunhas" element={<TestemunhasTable />} />
+                                </Route>
+                                <Route path="/import" element={<Navigate to="/admin/base-import" replace />} />
+                                <Route path="/admin/versoes" element={<Versions />} />
+                                <Route path="/admin/org" element={<Organization />} />
+                                <Route path="/admin/organization" element={<Organization />} />
+                                <Route path="/admin/logs" element={<Logs />} />
+                                <Route path="/admin/compliance" element={<Compliance />} />
+                                <Route path="/admin/marketing" element={<MarketingCompliance />} />
+                                <Route path="/admin/retencao" element={<DataRetention />} />
+                                <Route path="/admin/audit" element={<AuditPanel />} />
+                                <Route path="/admin/config" element={<SystemConfig />} />
+                                <Route path="/relatorio" element={<ReportDemo />} />
+
+                                <Route path="*" element={<NotFound />} />
+                              </Routes>
+                            </Suspense>
+                          </ErrorBoundary>
+                        </AppLayout>
+                      </AuthGuard>
+                    }
+                  />
+                </Routes>
+              </Suspense>
+            </BrowserRouter>
           </ConsentProvider>
         </TooltipProvider>
       </AuthProvider>

--- a/src/components/navigation/AppSidebar.tsx
+++ b/src/components/navigation/AppSidebar.tsx
@@ -103,10 +103,11 @@ export function AppSidebar() {
       >
         <SidebarHeader className="border-b border-sidebar-border p-4">
           <div className="flex items-center gap-3">
-            <img 
-              src="/lovable-uploads/7a3da188-83da-4e1d-b4e2-30254d487fae.png" 
-              alt="AssistJur.IA" 
+            <img
+              src="/lovable-uploads/7a3da188-83da-4e1d-b4e2-30254d487fae.png"
+              alt="AssistJur.IA"
               className="h-8 w-8 object-contain flex-shrink-0"
+              loading="lazy"
             />
             {open && (
               <div className="min-w-0">

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -58,10 +58,11 @@ const Login = () => {
           {/* Logo */}
           <div className="flex items-center justify-center mb-8 lg:hidden">
             <div className="flex items-center space-x-3">
-              <img 
-                src="/lovable-uploads/857f118f-dfc5-4d37-a64d-5f5caf7565f8.png" 
-                alt="AssistJur.IA Logo" 
+              <img
+                src="/lovable-uploads/857f118f-dfc5-4d37-a64d-5f5caf7565f8.png"
+                alt="AssistJur.IA Logo"
                 className="w-10 h-10 object-contain"
+                loading="lazy"
               />
               <div>
                 <h2 className="text-2xl font-bold text-foreground">AssistJur.IA</h2>
@@ -221,10 +222,11 @@ const Login = () => {
           <div className="absolute inset-0 flex flex-col justify-center p-12 text-primary-foreground">
             {/* Logo */}
             <div className="flex items-center space-x-3 mb-12">
-              <img 
-                src="/lovable-uploads/857f118f-dfc5-4d37-a64d-5f5caf7565f8.png" 
-                alt="AssistJur.IA Logo" 
+              <img
+                src="/lovable-uploads/857f118f-dfc5-4d37-a64d-5f5caf7565f8.png"
+                alt="AssistJur.IA Logo"
                 className="w-12 h-12 object-contain"
+                loading="lazy"
               />
               <div>
                 <h3 className="text-2xl font-bold">AssistJur.IA</h3>

--- a/src/pages/Reset.tsx
+++ b/src/pages/Reset.tsx
@@ -84,10 +84,11 @@ const Reset = () => {
           {/* Logo */}
           <div className="flex items-center justify-center mb-8">
             <div className="flex items-center space-x-3">
-              <img 
-                src="/lovable-uploads/857f118f-dfc5-4d37-a64d-5f5caf7565f8.png" 
-                alt="AssistJur.IA" 
+              <img
+                src="/lovable-uploads/857f118f-dfc5-4d37-a64d-5f5caf7565f8.png"
+                alt="AssistJur.IA"
                 className="w-10 h-10 object-contain"
+                loading="lazy"
               />
               <div>
                 <h1 className="text-2xl font-bold text-foreground">AssistJur.IA</h1>
@@ -162,10 +163,11 @@ const Reset = () => {
         {/* Logo */}
         <div className="flex items-center justify-center mb-8">
           <div className="flex items-center space-x-3">
-            <img 
-              src="/lovable-uploads/857f118f-dfc5-4d37-a64d-5f5caf7565f8.png" 
-              alt="AssistJur.IA" 
+            <img
+              src="/lovable-uploads/857f118f-dfc5-4d37-a64d-5f5caf7565f8.png"
+              alt="AssistJur.IA"
               className="w-10 h-10 object-contain"
+              loading="lazy"
             />
             <div>
               <h1 className="text-2xl font-bold text-foreground">AssistJur.IA</h1>

--- a/src/pages/VerifyOtp.tsx
+++ b/src/pages/VerifyOtp.tsx
@@ -68,10 +68,11 @@ const VerifyOtp = () => {
         {/* Logo */}
         <div className="flex items-center justify-center mb-8">
           <div className="flex items-center space-x-3">
-            <img 
-              src="/lovable-uploads/857f118f-dfc5-4d37-a64d-5f5caf7565f8.png" 
-              alt="AssistJur.IA" 
+            <img
+              src="/lovable-uploads/857f118f-dfc5-4d37-a64d-5f5caf7565f8.png"
+              alt="AssistJur.IA"
               className="w-10 h-10 object-contain"
+              loading="lazy"
             />
             <div>
             <h1 className="text-2xl font-bold text-foreground">AssistJur.IA</h1>


### PR DESCRIPTION
## Summary
- lazy-load route components with React Suspense
- lazy load sidebar and auth images

## Testing
- `npm test` (fails: vitest not found)
- `npm ci` (fails: 403 Forbidden when fetching packages)


------
https://chatgpt.com/codex/tasks/task_e_68c1e57a3e1c8322bfd6d1847e91fca2