### PR TITLE
feat: improve login accessibility and messaging

### DIFF
--- a/src/components/auth/EmailPasswordForm.tsx
+++ b/src/components/auth/EmailPasswordForm.tsx
@@ -12,14 +12,14 @@ import { useAuth } from "@/hooks/useAuth";
 import { validatePassword, MIN_PASSWORD_LENGTH } from "@/utils/security/passwordPolicy";
 
 const loginSchema = z.object({
-  email: z.string().email('E-mail inválido'),
+  email: z.string().email('Formato de email inválido'),
   password: z.string().min(6, 'Senha deve ter pelo menos 6 caracteres'),
   rememberMe: z.boolean().optional()
 });
 
 const signupSchema = z.object({
   name: z.string().min(2, 'Nome deve ter pelo menos 2 caracteres').optional(),
-  email: z.string().email('E-mail inválido'),
+  email: z.string().email('Formato de email inválido'),
   password: z.string()
     .min(MIN_PASSWORD_LENGTH, `Senha deve ter pelo menos ${MIN_PASSWORD_LENGTH} caracteres`),
   confirmPassword: z.string(),
@@ -50,6 +50,8 @@ export const EmailPasswordForm = ({
 
   const loginForm = useForm<LoginFormData>({
     resolver: zodResolver(loginSchema),
+    mode: 'onChange',
+    reValidateMode: 'onChange',
     defaultValues: {
       email: '',
       password: '',
@@ -76,6 +78,10 @@ export const EmailPasswordForm = ({
       const { error } = await signIn(data.email, data.password, 'OFFICE', data.rememberMe);
 
       if (error) {
+        if (error.message?.toLowerCase().includes('invalid login credentials')) {
+          loginForm.setError('password', { type: 'manual', message: 'Senha incorreta, tente novamente' });
+          return;
+        }
         throw error;
       }
 
@@ -140,7 +146,7 @@ export const EmailPasswordForm = ({
             className={signupForm.formState.errors.name ? 'border-destructive' : ''}
           />
           {signupForm.formState.errors.name && (
-            <p className="text-sm text-destructive">{signupForm.formState.errors.name.message}</p>
+            <p className="text-sm text-destructive" aria-live="polite">{signupForm.formState.errors.name.message}</p>
           )}
         </div>
 
@@ -155,7 +161,7 @@ export const EmailPasswordForm = ({
             className={signupForm.formState.errors.email ? 'border-destructive' : ''}
           />
           {signupForm.formState.errors.email && (
-            <p className="text-sm text-destructive">{signupForm.formState.errors.email.message}</p>
+            <p className="text-sm text-destructive" aria-live="polite">{signupForm.formState.errors.email.message}</p>
           )}
         </div>
 
@@ -185,7 +191,7 @@ export const EmailPasswordForm = ({
             </Button>
           </div>
           {signupForm.formState.errors.password && (
-            <p className="text-sm text-destructive">{signupForm.formState.errors.password.message}</p>
+            <p className="text-sm text-destructive" aria-live="polite">{signupForm.formState.errors.password.message}</p>
           )}
         </div>
 
@@ -215,7 +221,7 @@ export const EmailPasswordForm = ({
             </Button>
           </div>
           {signupForm.formState.errors.confirmPassword && (
-            <p className="text-sm text-destructive">{signupForm.formState.errors.confirmPassword.message}</p>
+            <p className="text-sm text-destructive" aria-live="polite">{signupForm.formState.errors.confirmPassword.message}</p>
           )}
         </div>
 
@@ -239,7 +245,7 @@ export const EmailPasswordForm = ({
           </Label>
         </div>
         {signupForm.formState.errors.acceptTerms && (
-          <p className="text-sm text-destructive">{signupForm.formState.errors.acceptTerms.message}</p>
+            <p className="text-sm text-destructive" aria-live="polite">{signupForm.formState.errors.acceptTerms.message}</p>
         )}
 
         {/* Submit Button */}
@@ -266,7 +272,7 @@ export const EmailPasswordForm = ({
             onClick={() => onModeChange('signin')}
             className="text-primary hover:underline font-medium"
           >
-            Entrar
+            Acessar área segura
           </button>
         </div>
       </form>
@@ -286,7 +292,7 @@ export const EmailPasswordForm = ({
           className={loginForm.formState.errors.email ? 'border-destructive' : ''}
         />
         {loginForm.formState.errors.email && (
-          <p className="text-sm text-destructive">{loginForm.formState.errors.email.message}</p>
+          <p className="text-sm text-destructive" aria-live="polite">{loginForm.formState.errors.email.message}</p>
         )}
       </div>
 
@@ -316,7 +322,7 @@ export const EmailPasswordForm = ({
           </Button>
         </div>
         {loginForm.formState.errors.password && (
-          <p className="text-sm text-destructive">{loginForm.formState.errors.password.message}</p>
+          <p className="text-sm text-destructive" aria-live="polite">{loginForm.formState.errors.password.message}</p>
         )}
       </div>
 
@@ -346,15 +352,15 @@ export const EmailPasswordForm = ({
       <Button 
         type="submit" 
         className="w-full" 
-        disabled={isLoading}
+        disabled={isLoading || !loginForm.formState.isValid}
       >
         {isLoading ? (
           <>
             <Loader2 className="h-4 w-4 animate-spin mr-2" />
-            Entrando...
+            Acessando...
           </>
         ) : (
-          'Entrar'
+          'Acessar área segura'
         )}
       </Button>
 

--- a/src/components/auth/MagicLinkForm.tsx
+++ b/src/components/auth/MagicLinkForm.tsx
@@ -10,7 +10,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 
 const magicLinkSchema = z.object({
-  email: z.string().email('E-mail inválido')
+  email: z.string().email('Formato de email inválido')
 });
 
 type MagicLinkFormData = z.infer<typeof magicLinkSchema>;
@@ -25,6 +25,8 @@ export const MagicLinkForm = ({ onBack }: MagicLinkFormProps) => {
 
   const form = useForm<MagicLinkFormData>({
     resolver: zodResolver(magicLinkSchema),
+    mode: 'onChange',
+    reValidateMode: 'onChange',
     defaultValues: {
       email: ''
     }
@@ -128,7 +130,7 @@ export const MagicLinkForm = ({ onBack }: MagicLinkFormProps) => {
         <div className="mx-auto p-3 bg-primary/10 rounded-full w-fit">
           <Mail className="h-6 w-6 text-primary" />
         </div>
-        <h3 className="text-lg font-semibold">Entrar com link</h3>
+        <h3 className="text-lg font-semibold">Acessar área segura com link</h3>
         <p className="text-sm text-muted-foreground">
           Enviaremos um link de acesso seguro para o seu e-mail
         </p>
@@ -146,7 +148,7 @@ export const MagicLinkForm = ({ onBack }: MagicLinkFormProps) => {
             autoFocus
           />
           {form.formState.errors.email && (
-            <p className="text-sm text-destructive">{form.formState.errors.email.message}</p>
+            <p className="text-sm text-destructive" aria-live="polite">{form.formState.errors.email.message}</p>
           )}
         </div>
 

--- a/src/components/auth/OAuthButtons.tsx
+++ b/src/components/auth/OAuthButtons.tsx
@@ -128,7 +128,7 @@ export const OAuthButtons = ({ disabled, next }: OAuthButtonsProps) => {
             onClick={() => handleOAuthSignIn('google')}
             disabled={disabled || loadingProvider !== null}
             className="w-full transition-all duration-200 hover:shadow-md"
-            aria-label="Entrar com Google"
+            aria-label="Acessar área segura com Google"
           >
             {loadingProvider === 'google' ? (
               <div className="flex items-center space-x-2">

--- a/src/components/home/Header.tsx
+++ b/src/components/home/Header.tsx
@@ -62,11 +62,11 @@ export const Header = () => {
               <User className="w-5 h-5" />
             </Button>
           ) : (
-            <Button 
-              variant="professional" 
+            <Button
+              variant="professional"
               onClick={() => navigate('/login')}
             >
-              Entrar
+              Acessar área segura
             </Button>
           )}
         </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -94,7 +94,7 @@ const Login = () => {
           {/* Magic Link Form or Auth Form */}
           {showMagicLink && AUTH_CONFIG.FEATURES.MAGIC_LINK_ENABLED ? (
             <AuthCard
-              title="Entrar com link"
+              title="Acessar área segura com link"
               description="Acesso seguro sem senha"
             >
               <MagicLinkForm onBack={() => setShowMagicLink(false)} />
@@ -115,13 +115,13 @@ const Login = () => {
                   className="w-full"
                 >
                   <TabsList className="grid w-full grid-cols-2" role="tablist">
-                    <TabsTrigger 
-                      value="signin" 
+                    <TabsTrigger
+                      value="signin"
                       role="tab"
                       aria-selected={activeTab === 'signin'}
                       aria-controls="signin-panel"
                     >
-                      Entrar
+                      Acessar área segura
                     </TabsTrigger>
                     <TabsTrigger 
                       value="signup"
@@ -153,9 +153,9 @@ const Login = () => {
                           type="button"
                           onClick={handleMagicLinkToggle}
                           className="text-sm text-primary hover:underline focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded-sm px-1 py-0.5"
-                          aria-label="Alternar para login com link de e-mail"
+                          aria-label="Alternar para acesso com link de e-mail"
                         >
-                          Entrar com link de e-mail
+                          Acessar área segura com link de e-mail
                         </button>
                       </div>
                     )}


### PR DESCRIPTION
## Summary
- rename login actions from "Entrar" to "Acessar área segura"
- show specific error messages and live validation for email/password
- add aria-live handling and disable submit on invalid input

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for @testing-library/dom)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e5b779648322b4257b82c99c73ff