### PR TITLE
Add route progress indicator and accessible skeleton loaders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { AuthProvider } from "@/hooks/useAuth";
 import AuthGuard from "@/components/AuthGuard";
 import { AppLayout } from "@/components/navigation/AppLayout";
 import { ErrorBoundary } from "@/components/core/ErrorBoundary";
+import { RouteProgressBar } from '@/components/navigation/RouteProgressBar';
 
 import MapaPage from "./pages/MapaPage";
 import PublicHome from "./pages/PublicHome";
@@ -77,6 +78,7 @@ const App = () => (
               v7_relativeSplatPath: true,
             }}
           >
+            <RouteProgressBar />
             <Routes>
               {/* Public routes */}
               <Route path="/" element={<PublicHome />} />

--- a/src/components/assistjur/ProcessosDataTable.tsx
+++ b/src/components/assistjur/ProcessosDataTable.tsx
@@ -12,21 +12,23 @@ import { Eye, Download, Filter, X, ExternalLink, Bug } from 'lucide-react';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { toast } from 'sonner';
+import { useLoadingDelay } from '@/hooks/useLoadingDelay';
 
 export function ProcessosDataTable() {
   const [filters, setFilters] = useState<ProcessosFilters>({});
   const [isPiiMasked, setIsPiiMasked] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
 
-  const { 
-    data: processos, 
-    totalCount, 
-    currentPage, 
-    totalPages, 
-    isLoading, 
-    error, 
-    setPage 
+  const {
+    data: processos,
+    totalCount,
+    currentPage,
+    totalPages,
+    isLoading,
+    error,
+    setPage
   } = useAssistJurProcessos(filters);
+  const showSkeleton = useLoadingDelay(isLoading);
 
   const handleSearchChange = (search: string) => {
     setFilters(prev => ({ ...prev, search: search.trim() || undefined }));
@@ -210,9 +212,11 @@ export function ProcessosDataTable() {
                 <TableHead className="font-semibold text-center">Ações</TableHead>
               </TableRow>
             </TableHeader>
-            <TableBody>
-              {isLoading ? (
-                Array.from({ length: 5 }).map((_, i) => (
+            <TableBody aria-busy={showSkeleton}>
+              {showSkeleton ? (
+                <>
+                <span className="sr-only">Carregando dados jurídicos…</span>
+                {Array.from({ length: 5 }).map((_, i) => (
                   <TableRow key={i}>
                     <TableCell className="h-16">
                       <div className="animate-pulse bg-muted rounded h-4 w-24" />
@@ -242,7 +246,8 @@ export function ProcessosDataTable() {
                       <div className="animate-pulse bg-muted rounded h-4 w-8" />
                     </TableCell>
                   </TableRow>
-                ))
+                ))}
+                </>
               ) : processos.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={9} className="text-center py-8">

--- a/src/components/core/LoadingStates.tsx
+++ b/src/components/core/LoadingStates.tsx
@@ -88,7 +88,8 @@ export function ConversationListSkeleton() {
 // Skeleton for data cards
 export function DataCardSkeleton() {
   return (
-    <Card>
+    <Card aria-busy="true">
+      <span className="sr-only">Carregando dados jurídicos…</span>
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
@@ -121,14 +122,15 @@ export function DataCardSkeleton() {
 // Table loading skeleton
 export function TableSkeleton({ rows = 5, cols = 4 }: { rows?: number; cols?: number }) {
   return (
-    <div className="space-y-4">
+    <div className="space-y-4" aria-busy="true">
+      <span className="sr-only">Carregando dados jurídicos…</span>
       {/* Header */}
       <div className="flex gap-4">
         {[...Array(cols)].map((_, i) => (
           <Skeleton key={i} className="h-6 flex-1" />
         ))}
       </div>
-      
+
       {/* Rows */}
       {[...Array(rows)].map((_, rowIndex) => (
         <div key={rowIndex} className="flex gap-4">

--- a/src/components/navigation/RouteProgressBar.tsx
+++ b/src/components/navigation/RouteProgressBar.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export function RouteProgressBar() {
+  const location = useLocation();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    const timeout = setTimeout(() => setLoading(false), 500);
+    return () => clearTimeout(timeout);
+  }, [location]);
+
+  return (
+    <div
+      aria-busy={loading}
+      className={`fixed top-0 left-0 right-0 h-1 bg-primary transition-all duration-300 z-50 ${
+        loading ? 'w-full opacity-100' : 'w-0 opacity-0'
+      }`}
+    >
+      {loading && <span className="sr-only">Carregando dados jurídicos…</span>}
+    </div>
+  );
+}

--- a/src/hooks/useLoadingDelay.ts
+++ b/src/hooks/useLoadingDelay.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Ensures loading indicators remain visible for at least `delay` ms.
+ * Useful to prevent flicker when data loads too quickly.
+ */
+export function useLoadingDelay(isLoading: boolean, delay = 300) {
+  const [show, setShow] = useState(isLoading);
+
+  useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>;
+
+    if (isLoading) {
+      setShow(true);
+    } else {
+      timeout = setTimeout(() => setShow(false), delay);
+    }
+
+    return () => {
+      if (timeout) clearTimeout(timeout);
+    };
+  }, [isLoading, delay]);
+
+  return show;
+}

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -27,6 +27,8 @@ import {
 import { ReviewUpdateButton } from '@/components/admin/ReviewUpdateButton';
 import { DatabaseCleanupButton } from '@/components/admin/DatabaseCleanupButton';
 import { WitnessDataProcessor } from '@/components/admin/WitnessDataProcessor';
+import { DataCardSkeleton } from '@/components/core/LoadingStates';
+import { useLoadingDelay } from '@/hooks/useLoadingDelay';
 
 interface OverviewData {
   counts: {
@@ -65,6 +67,7 @@ interface RiskPatternData {
 const Dashboard = () => {
   const { user } = useAuth();
   const [loading, setLoading] = useState(true);
+  const showSkeleton = useLoadingDelay(loading);
   const [overviewData, setOverviewData] = useState<OverviewData | null>(null);
   const [usageData, setUsageData] = useState<UsageData | null>(null);
   const [riskPatternData, setRiskPatternData] = useState<RiskPatternData | null>(null);
@@ -108,10 +111,13 @@ const Dashboard = () => {
     }
   };
 
-  if (loading) {
+  if (showSkeleton) {
     return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary"></div>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4" aria-busy="true">
+        <span className="sr-only">Carregando dados jurídicos…</span>
+        {Array.from({ length: 4 }).map((_, i) => (
+          <DataCardSkeleton key={i} />
+        ))}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- show top progress bar when navigating between routes
- add reusable hook for delayed loading states
- implement accessible skeletons for cards and tables

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c1e60ac8808322b272a3ebeda8303c