### PR TITLE
feat: add reusable brand logo component

### DIFF
--- a/src/components/beta/BetaHeader.tsx
+++ b/src/components/beta/BetaHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { BRAND } from '@/branding/brand';
+import { BrandLogo } from '@/components/brand/BrandLogo';
 
 export function BetaHeader() {
   const navigate = useNavigate();
@@ -13,11 +13,7 @@ export function BetaHeader() {
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
           <div className="flex items-center space-x-3 cursor-pointer transition-transform duration-200 hover:scale-105" onClick={() => navigate('/')}>
-            <img 
-              src={BRAND.logo.light}
-              alt={BRAND.name} 
-              className="h-10 md:h-12 object-contain"
-            />
+            <BrandLogo size="lg" className="h-10 md:h-12" />
           </div>
 
           {/* Navigation */}

--- a/src/components/brand/BrandHeader.tsx
+++ b/src/components/brand/BrandHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BRAND } from '@/branding/brand';
+import { BrandLogo } from '@/components/brand/BrandLogo';
 
 interface BrandHeaderProps {
   size?: 'sm' | 'md' | 'lg';
@@ -39,11 +40,7 @@ export function BrandHeader({
 
   return (
     <div className={`${classes.container} ${className}`}>
-      <img 
-        src={BRAND.logo.light} 
-        alt={`${BRAND.name} Logo`}
-        className={classes.logo}
-      />
+      <BrandLogo size={size} className={classes.logo} />
       <div>
         <h1 className={`${classes.title} text-brand-ink`}>
           {BRAND.name}

--- a/src/components/brand/BrandLogo.tsx
+++ b/src/components/brand/BrandLogo.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { BRAND } from '@/branding/brand';
+import { cn } from '@/lib/utils';
+
+export interface BrandLogoProps {
+  size?: 'sm' | 'md' | 'lg';
+  variation?: 'light' | 'dark' | 'mark';
+  className?: string;
+}
+
+const sizeClasses: Record<NonNullable<BrandLogoProps['size']>, string> = {
+  sm: 'h-6',
+  md: 'h-8',
+  lg: 'h-10',
+};
+
+export function BrandLogo({ size = 'md', variation = 'light', className }: BrandLogoProps) {
+  return (
+    <img
+      src={BRAND.logo[variation]}
+      alt={BRAND.name}
+      className={cn('w-auto object-contain', sizeClasses[size], className)}
+    />
+  );
+}
+
+export default BrandLogo;

--- a/src/components/home/Header.tsx
+++ b/src/components/home/Header.tsx
@@ -5,7 +5,7 @@ import { Scale, User } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
 import { GlobalSearch } from "./GlobalSearch";
 import { LastUpdateBadge } from "@/components/ui/LastUpdateBadge";
-import { BRAND } from "@/branding/brand";
+import { BrandLogo } from "@/components/brand/BrandLogo";
 
 export const Header = () => {
   const navigate = useNavigate();
@@ -28,11 +28,7 @@ export const Header = () => {
       <div className="container mx-auto px-4 py-4 flex items-center justify-between gap-4">
         {/* Logo */}
         <div className="flex items-center gap-3 min-w-fit cursor-pointer transition-transform duration-200 hover:scale-105" onClick={() => navigate('/')}>
-          <img 
-            src={BRAND.logo.light}
-            alt={BRAND.name} 
-            className="h-10 md:h-12 object-contain"
-          />
+          <BrandLogo size="lg" className="h-10 md:h-12" />
         </div>
 
         {/* Search */}

--- a/src/components/navigation/AppSidebar.tsx
+++ b/src/components/navigation/AppSidebar.tsx
@@ -17,12 +17,12 @@ import { useAuth } from '@/hooks/useAuth';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/use-toast';
 import { useConsent } from '@/hooks/useConsent';
-import { 
-  DropdownMenu, 
-  DropdownMenuContent, 
-  DropdownMenuItem, 
-  DropdownMenuSeparator, 
-  DropdownMenuTrigger 
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
@@ -30,11 +30,12 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { NAV_GROUPS } from '@/config/sidebar';
 import { ThemeToggle } from './ThemeToggle';
 import { CommandPalette } from './CommandPalette';
-import { 
+import {
   User,
   LogOut,
   UserCog
 } from 'lucide-react';
+import { BrandLogo } from '@/components/brand/BrandLogo';
 
 export function AppSidebar() {
   const { open, setOpen, openMobile, setOpenMobile, isMobile, state } = useSidebar();
@@ -103,11 +104,10 @@ export function AppSidebar() {
       >
         <SidebarHeader className="border-b border-sidebar-border p-4">
           <div className="flex items-center gap-3">
-            <img
-              src="/lovable-uploads/7a3da188-83da-4e1d-b4e2-30254d487fae.png"
-              alt="AssistJur.IA"
-              className="h-8 w-8 object-contain flex-shrink-0"
-              loading="lazy"
+            <BrandLogo
+              variation="mark"
+              size="md"
+              className="flex-shrink-0"
             />
             {open && (
               <div className="min-w-0">

--- a/src/components/site/Hero.tsx
+++ b/src/components/site/Hero.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { ArrowDown } from 'lucide-react';
 import { NeedsForm } from './NeedsForm';
-import { BRAND } from '@/branding/brand';
+import { BrandLogo } from '@/components/brand/BrandLogo';
 
 interface HeroProps {
   onSignup?: (data: { email: string; needs: string[]; otherNeed?: string }) => void;
@@ -31,11 +31,7 @@ export function Hero({ onSignup }: HeroProps) {
           {/* Logo e Tagline */}
           <div className="space-y-4">
             <div className="inline-flex items-center space-x-3 mb-4">
-              <img 
-                src={BRAND.logo.light}
-                alt={BRAND.name} 
-                className="h-16 md:h-20 object-contain"
-              />
+              <BrandLogo size="lg" className="h-16 md:h-20" />
             </div>
             <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
               Gestão do contencioso com inovação e olhar estratégico

--- a/src/components/site/PublicHeader.tsx
+++ b/src/components/site/PublicHeader.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Menu, X, ChevronDown } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { BRAND } from '@/branding/brand';
+import { BrandLogo } from '@/components/brand/BrandLogo';
 
 interface PublicHeaderProps {
   onBetaClick?: () => void;
@@ -68,10 +68,9 @@ export function PublicHeader({ onBetaClick }: PublicHeaderProps) {
         <div className="flex items-center justify-between h-18">
           {/* Logo */}
           <div className="flex items-center cursor-pointer transition-transform duration-200 hover:scale-105 mr-8" onClick={() => scrollToSection('hero')}>
-            <img 
-              src={BRAND.logo.light}
-              alt={BRAND.name} 
-              className="h-14 md:h-16 object-contain filter brightness-0 saturate-100 hue-rotate-258 contrast-125"
+            <BrandLogo
+              size="lg"
+              className="h-14 md:h-16 filter brightness-0 saturate-100 hue-rotate-258 contrast-125"
             />
           </div>
 

--- a/src/components/sobre/AboutHeader.tsx
+++ b/src/components/sobre/AboutHeader.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
-import { BRAND } from '@/branding/brand';
+import { BrandLogo } from '@/components/brand/BrandLogo';
 
 interface AboutHeaderProps {
   onOpenBetaModal?: () => void;
@@ -36,11 +36,7 @@ export function AboutHeader({ onOpenBetaModal }: AboutHeaderProps) {
           {/* Logo */}
           <div className="flex items-center">
             <button onClick={() => navigate('/')} className="flex items-center transition-transform duration-200 hover:scale-105">
-              <img 
-                src={BRAND.logo.light}
-                alt={BRAND.name} 
-                className="h-10 md:h-12 object-contain"
-              />
+              <BrandLogo size="lg" className="md:h-12" />
             </button>
           </div>
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -10,6 +10,7 @@ import { AlertBox } from '@/components/auth/AlertBox';
 import { useAuth } from '@/hooks/useAuth';
 import { getDefaultRedirect, AUTH_CONFIG } from '@/config/auth';
 import heroImage from "@/assets/hero-legal-tech.jpg";
+import { BrandLogo } from '@/components/brand/BrandLogo';
 
 const Login = () => {
   const navigate = useNavigate();
@@ -58,12 +59,7 @@ const Login = () => {
           {/* Logo */}
           <div className="flex items-center justify-center mb-8 lg:hidden">
             <div className="flex items-center space-x-3">
-              <img
-                src="/lovable-uploads/857f118f-dfc5-4d37-a64d-5f5caf7565f8.png"
-                alt="AssistJur.IA Logo"
-                className="w-10 h-10 object-contain"
-                loading="lazy"
-              />
+              <BrandLogo size="md" className="w-10 h-10" />
               <div>
                 <h2 className="text-2xl font-bold text-foreground">AssistJur.IA</h2>
                 <p className="text-sm text-muted-foreground">Assistente de Testemunhas</p>
@@ -222,17 +218,12 @@ const Login = () => {
           <div className="absolute inset-0 flex flex-col justify-center p-12 text-primary-foreground">
             {/* Logo */}
             <div className="flex items-center space-x-3 mb-12">
-              <img
-                src="/lovable-uploads/857f118f-dfc5-4d37-a64d-5f5caf7565f8.png"
-                alt="AssistJur.IA Logo"
-                className="w-12 h-12 object-contain"
-                loading="lazy"
-              />
-              <div>
-                <h3 className="text-2xl font-bold">AssistJur.IA</h3>
-                <p className="text-sm opacity-80">Assistente de Testemunhas</p>
-              </div>
+            <BrandLogo size="lg" className="w-12 h-12" />
+            <div>
+              <h3 className="text-2xl font-bold">AssistJur.IA</h3>
+              <p className="text-sm opacity-80">Assistente de Testemunhas</p>
             </div>
+          </div>
 
             {/* Headline */}
             <div className="space-y-6">

--- a/src/pages/Reset.tsx
+++ b/src/pages/Reset.tsx
@@ -11,6 +11,7 @@ import { AuthCard } from '@/components/auth/AuthCard';
 import { AlertBox } from '@/components/auth/AlertBox';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import { BrandLogo } from '@/components/brand/BrandLogo';
 
 const resetSchema = z.object({
   email: z.string().email('E-mail inválido')
@@ -84,12 +85,7 @@ const Reset = () => {
           {/* Logo */}
           <div className="flex items-center justify-center mb-8">
             <div className="flex items-center space-x-3">
-              <img
-                src="/lovable-uploads/857f118f-dfc5-4d37-a64d-5f5caf7565f8.png"
-                alt="AssistJur.IA"
-                className="w-10 h-10 object-contain"
-                loading="lazy"
-              />
+              <BrandLogo size="md" className="w-10 h-10" />
               <div>
                 <h1 className="text-2xl font-bold text-foreground">AssistJur.IA</h1>
                 <p className="text-sm text-muted-foreground">Assistente de Testemunhas</p>
@@ -159,16 +155,11 @@ const Reset = () => {
 
   return (
     <div className="min-h-screen bg-gradient-subtle flex flex-col justify-center px-6 py-12">
-      <div className="mx-auto w-full max-w-md">
+        <div className="mx-auto w-full max-w-md">
         {/* Logo */}
         <div className="flex items-center justify-center mb-8">
           <div className="flex items-center space-x-3">
-            <img
-              src="/lovable-uploads/857f118f-dfc5-4d37-a64d-5f5caf7565f8.png"
-              alt="AssistJur.IA"
-              className="w-10 h-10 object-contain"
-              loading="lazy"
-            />
+            <BrandLogo size="md" className="w-10 h-10" />
             <div>
               <h1 className="text-2xl font-bold text-foreground">AssistJur.IA</h1>
               <p className="text-sm text-muted-foreground">Assistente de Testemunhas</p>

--- a/src/pages/VerifyOtp.tsx
+++ b/src/pages/VerifyOtp.tsx
@@ -5,6 +5,7 @@ import { AuthCard } from '@/components/auth/AuthCard';
 import { TwoFactorForm } from '@/components/auth/TwoFactorForm';
 import { AlertBox } from '@/components/auth/AlertBox';
 import { useAuth } from '@/hooks/useAuth';
+import { BrandLogo } from '@/components/brand/BrandLogo';
 
 const VerifyOtp = () => {
   const navigate = useNavigate();
@@ -68,12 +69,7 @@ const VerifyOtp = () => {
         {/* Logo */}
         <div className="flex items-center justify-center mb-8">
           <div className="flex items-center space-x-3">
-            <img
-              src="/lovable-uploads/857f118f-dfc5-4d37-a64d-5f5caf7565f8.png"
-              alt="AssistJur.IA"
-              className="w-10 h-10 object-contain"
-              loading="lazy"
-            />
+            <BrandLogo size="md" className="w-10 h-10" />
             <div>
             <h1 className="text-2xl font-bold text-foreground">AssistJur.IA</h1>
             <p className="text-sm text-muted-foreground">Assistente de Testemunhas</p>


### PR DESCRIPTION
## Summary
- create `BrandLogo` component with size and variation props for light, dark and mark logos
- replace scattered `<img>` tags with `<BrandLogo />` across pages and navigation
- standardize logo alt text and sizing classes

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c1e7105fc08322901c2f5b7a90ca5f