### PR TITLE
Use double quotes for consent imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,8 @@ import React, { Suspense, lazy } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { ConsentProvider } from '@/hooks/useConsent'
-import ConsentDialog from '@/components/privacy/ConsentDialog';
+import { ConsentProvider } from "@/hooks/useConsent";
+import ConsentDialog from "@/components/privacy/ConsentDialog";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { AuthProvider } from "@/hooks/useAuth";


### PR DESCRIPTION
## Summary
- normalize consent imports in App.tsx to use double quotes

## Testing
- `npx eslint src/App.tsx` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e99a79a083228c5be9577af3e3c9