### PR TITLE
refactor: use BrandHeader on auth pages

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { Scale } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { AuthCard } from '@/components/auth/AuthCard';
 import { OAuthButtons } from '@/components/auth/OAuthButtons';
@@ -10,7 +9,7 @@ import { AlertBox } from '@/components/auth/AlertBox';
 import { useAuth } from '@/hooks/useAuth';
 import { getDefaultRedirect, AUTH_CONFIG } from '@/config/auth';
 import heroImage from "@/assets/hero-legal-tech.jpg";
-import { BrandLogo } from '@/components/brand/BrandLogo';
+import { BrandHeader } from '@/components/brand/BrandHeader';
 
 const Login = () => {
   const navigate = useNavigate();
@@ -58,13 +57,7 @@ const Login = () => {
         <div className="mx-auto w-full max-w-md">
           {/* Logo */}
           <div className="flex items-center justify-center mb-8 lg:hidden">
-            <div className="flex items-center space-x-3">
-              <BrandLogo size="md" className="w-10 h-10" />
-              <div>
-                <h2 className="text-2xl font-bold text-foreground">AssistJur.IA</h2>
-                <p className="text-sm text-muted-foreground">Assistente de Testemunhas</p>
-              </div>
-            </div>
+            <BrandHeader size="lg" className="gap-3" />
           </div>
 
           {/* Error Banner */}
@@ -217,13 +210,7 @@ const Login = () => {
         >
           <div className="absolute inset-0 flex flex-col justify-center p-12 text-primary-foreground">
             {/* Logo */}
-            <div className="flex items-center space-x-3 mb-12">
-            <BrandLogo size="lg" className="w-12 h-12" />
-            <div>
-              <h3 className="text-2xl font-bold">AssistJur.IA</h3>
-              <p className="text-sm opacity-80">Assistente de Testemunhas</p>
-            </div>
-          </div>
+            <BrandHeader size="lg" className="mb-12 gap-3" />
 
             {/* Headline */}
             <div className="space-y-6">

--- a/src/pages/Reset.tsx
+++ b/src/pages/Reset.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { Scale, ArrowLeft, Mail, Loader2, CheckCircle } from 'lucide-react';
+import { ArrowLeft, Mail, Loader2, CheckCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -11,7 +11,7 @@ import { AuthCard } from '@/components/auth/AuthCard';
 import { AlertBox } from '@/components/auth/AlertBox';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
-import { BrandLogo } from '@/components/brand/BrandLogo';
+import { BrandHeader } from '@/components/brand/BrandHeader';
 
 const resetSchema = z.object({
   email: z.string().email('E-mail inválido')
@@ -84,13 +84,7 @@ const Reset = () => {
         <div className="mx-auto w-full max-w-md">
           {/* Logo */}
           <div className="flex items-center justify-center mb-8">
-            <div className="flex items-center space-x-3">
-              <BrandLogo size="md" className="w-10 h-10" />
-              <div>
-                <h1 className="text-2xl font-bold text-foreground">AssistJur.IA</h1>
-                <p className="text-sm text-muted-foreground">Assistente de Testemunhas</p>
-              </div>
-            </div>
+            <BrandHeader size="lg" className="gap-3" />
           </div>
 
           <AuthCard
@@ -158,13 +152,7 @@ const Reset = () => {
         <div className="mx-auto w-full max-w-md">
         {/* Logo */}
         <div className="flex items-center justify-center mb-8">
-          <div className="flex items-center space-x-3">
-            <BrandLogo size="md" className="w-10 h-10" />
-            <div>
-              <h1 className="text-2xl font-bold text-foreground">AssistJur.IA</h1>
-              <p className="text-sm text-muted-foreground">Assistente de Testemunhas</p>
-            </div>
-          </div>
+          <BrandHeader size="lg" className="gap-3" />
         </div>
 
         <AuthCard

--- a/src/pages/VerifyOtp.tsx
+++ b/src/pages/VerifyOtp.tsx
@@ -1,11 +1,10 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { Scale } from 'lucide-react';
 import { AuthCard } from '@/components/auth/AuthCard';
 import { TwoFactorForm } from '@/components/auth/TwoFactorForm';
 import { AlertBox } from '@/components/auth/AlertBox';
 import { useAuth } from '@/hooks/useAuth';
-import { BrandLogo } from '@/components/brand/BrandLogo';
+import { BrandHeader } from '@/components/brand/BrandHeader';
 
 const VerifyOtp = () => {
   const navigate = useNavigate();
@@ -68,13 +67,7 @@ const VerifyOtp = () => {
       <div className="mx-auto w-full max-w-md">
         {/* Logo */}
         <div className="flex items-center justify-center mb-8">
-          <div className="flex items-center space-x-3">
-            <BrandLogo size="md" className="w-10 h-10" />
-            <div>
-            <h1 className="text-2xl font-bold text-foreground">AssistJur.IA</h1>
-            <p className="text-sm text-muted-foreground">Assistente de Testemunhas</p>
-            </div>
-          </div>
+          <BrandHeader size="lg" className="gap-3" />
         </div>
 
         {/* MFA Info */}


### PR DESCRIPTION
## Summary
- replace brand logo+text with BrandHeader in login, OTP, and reset pages
- remove unused icon imports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f42af2f483229f1ab9f303851077