### PR TITLE
refactor: modularize admin routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { AuthProvider } from "@/hooks/useAuth";
 import AuthGuard from "@/components/AuthGuard";
 import { AppLayout } from "@/components/navigation/AppLayout";
 import { ErrorBoundary } from "@/components/core/ErrorBoundary";
+import AdminRoutes from "./routes/AdminRoutes";
 
 const MapaPage = lazy(() => import("./pages/MapaPage"));
 const PublicHome = lazy(() => import("./pages/PublicHome"));
@@ -22,33 +23,8 @@ const VerifyOtp = lazy(() => import("./pages/VerifyOtp"));
 const PortalTitular = lazy(() => import("./pages/PortalTitular"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 const DemoMapaTestemunhas = lazy(() => import("./pages/DemoMapaTestemunhas"));
-
-const Dashboard = lazy(() => import("./pages/admin/Dashboard"));
-const Analytics = lazy(() => import("./pages/admin/Analytics"));
-const ImportBase = lazy(() => import("./pages/admin/ImportBase"));
 const TemplatePage = lazy(() => import("./pages/TemplatePage"));
-const Versions = lazy(() => import("./pages/admin/Versions"));
-const Organization = lazy(() => import("./pages/admin/Organization"));
-
-const SystemConfig = lazy(() => import("./pages/admin/SystemConfig"));
-const Compliance = lazy(() => import("./pages/admin/Compliance"));
-const MarketingCompliance = lazy(() => import("./pages/admin/MarketingCompliance"));
-const DataRetention = lazy(() => import("./pages/admin/DataRetention"));
-const AuditPanel = lazy(() => import("./pages/admin/AuditPanel"));
-const OpenAI = lazy(() => import("./pages/admin/OpenAI"));
-const OpenAIKeys = lazy(() => import("./pages/admin/openai/Keys"));
-const OpenAIModels = lazy(() => import("./pages/admin/openai/Models"));
-const PromptStudio = lazy(() => import("./pages/admin/openai/PromptStudio"));
-const OpenAIPlayground = lazy(() => import("./pages/admin/openai/Playground"));
-const Logs = lazy(() => import("./pages/admin/Logs"));
 const ReportDemo = lazy(() => import("./pages/ReportDemo"));
-const ValidationTest = lazy(() => import("./pages/admin/ValidationTest"));
-
-// Data Explorer components
-const BaseRedirect = lazy(() => import("./pages/admin/base/index"));
-const BaseLayout = lazy(() => import("./pages/admin/base/BaseLayout"));
-const ProcessosTable = lazy(() => import("./pages/admin/base/ProcessosTable"));
-const TestemunhasTable = lazy(() => import("./pages/admin/base/TestemunhasTable"));
 
 // React Query client configuration
 const queryClient = new QueryClient({
@@ -109,30 +85,8 @@ const App = () => (
                                 <Route path="/app/chat" element={<Navigate to="/mapa-testemunhas?view=chat" replace />} />
 
                                 {/* Admin routes */}
-                                <Route path="/admin" element={<Dashboard />} />
-                                <Route path="/admin/analytics" element={<Analytics />} />
-                                <Route path="/admin/ia" element={<OpenAI />} />
-                                <Route path="/admin/ia/chaves" element={<OpenAIKeys />} />
-                                <Route path="/admin/ia/modelos" element={<OpenAIModels />} />
-                                <Route path="/admin/ia/prompt-studio" element={<PromptStudio />} />
-                                <Route path="/admin/ia/testes" element={<OpenAIPlayground />} />
-                                <Route path="/admin/base-import" element={<ImportBase />} />
-                                <Route path="/admin/base-import/test" element={<ValidationTest />} />
-                                <Route path="/admin/base" element={<BaseRedirect />} />
-                                <Route path="/admin/base/*" element={<BaseLayout />}>
-                                  <Route path="processos" element={<ProcessosTable />} />
-                                  <Route path="testemunhas" element={<TestemunhasTable />} />
-                                </Route>
+                                <AdminRoutes />
                                 <Route path="/import" element={<Navigate to="/admin/base-import" replace />} />
-                                <Route path="/admin/versoes" element={<Versions />} />
-                                <Route path="/admin/org" element={<Organization />} />
-                                <Route path="/admin/organization" element={<Organization />} />
-                                <Route path="/admin/logs" element={<Logs />} />
-                                <Route path="/admin/compliance" element={<Compliance />} />
-                                <Route path="/admin/marketing" element={<MarketingCompliance />} />
-                                <Route path="/admin/retencao" element={<DataRetention />} />
-                                <Route path="/admin/audit" element={<AuditPanel />} />
-                                <Route path="/admin/config" element={<SystemConfig />} />
                                 <Route path="/relatorio" element={<ReportDemo />} />
 
                                 <Route path="*" element={<NotFound />} />

--- a/src/routes/AdminRoutes.tsx
+++ b/src/routes/AdminRoutes.tsx
@@ -1,0 +1,57 @@
+import React, { lazy } from "react";
+import { Route } from "react-router-dom";
+
+const Dashboard = lazy(() => import("@/pages/admin/Dashboard"));
+const Analytics = lazy(() => import("@/pages/admin/Analytics"));
+const ImportBase = lazy(() => import("@/pages/admin/ImportBase"));
+const Versions = lazy(() => import("@/pages/admin/Versions"));
+const Organization = lazy(() => import("@/pages/admin/Organization"));
+const SystemConfig = lazy(() => import("@/pages/admin/SystemConfig"));
+const Compliance = lazy(() => import("@/pages/admin/Compliance"));
+const MarketingCompliance = lazy(() => import("@/pages/admin/MarketingCompliance"));
+const DataRetention = lazy(() => import("@/pages/admin/DataRetention"));
+const AuditPanel = lazy(() => import("@/pages/admin/AuditPanel"));
+const OpenAI = lazy(() => import("@/pages/admin/OpenAI"));
+const OpenAIKeys = lazy(() => import("@/pages/admin/openai/Keys"));
+const OpenAIModels = lazy(() => import("@/pages/admin/openai/Models"));
+const PromptStudio = lazy(() => import("@/pages/admin/openai/PromptStudio"));
+const OpenAIPlayground = lazy(() => import("@/pages/admin/openai/Playground"));
+const Logs = lazy(() => import("@/pages/admin/Logs"));
+const ValidationTest = lazy(() => import("@/pages/admin/ValidationTest"));
+
+// Data Explorer components
+const BaseRedirect = lazy(() => import("@/pages/admin/base/index"));
+const BaseLayout = lazy(() => import("@/pages/admin/base/BaseLayout"));
+const ProcessosTable = lazy(() => import("@/pages/admin/base/ProcessosTable"));
+const TestemunhasTable = lazy(() => import("@/pages/admin/base/TestemunhasTable"));
+
+const AdminRoutes = () => (
+  <>
+    <Route path="/admin" element={<Dashboard />} />
+    <Route path="/admin/analytics" element={<Analytics />} />
+    <Route path="/admin/ia" element={<OpenAI />} />
+    <Route path="/admin/ia/chaves" element={<OpenAIKeys />} />
+    <Route path="/admin/ia/modelos" element={<OpenAIModels />} />
+    <Route path="/admin/ia/prompt-studio" element={<PromptStudio />} />
+    <Route path="/admin/ia/testes" element={<OpenAIPlayground />} />
+    <Route path="/admin/base-import" element={<ImportBase />} />
+    <Route path="/admin/base-import/test" element={<ValidationTest />} />
+    <Route path="/admin/base" element={<BaseRedirect />} />
+    <Route path="/admin/base/*" element={<BaseLayout />}>
+      <Route path="processos" element={<ProcessosTable />} />
+      <Route path="testemunhas" element={<TestemunhasTable />} />
+    </Route>
+    <Route path="/admin/versoes" element={<Versions />} />
+    <Route path="/admin/org" element={<Organization />} />
+    <Route path="/admin/organization" element={<Organization />} />
+    <Route path="/admin/logs" element={<Logs />} />
+    <Route path="/admin/compliance" element={<Compliance />} />
+    <Route path="/admin/marketing" element={<MarketingCompliance />} />
+    <Route path="/admin/retencao" element={<DataRetention />} />
+    <Route path="/admin/audit" element={<AuditPanel />} />
+    <Route path="/admin/config" element={<SystemConfig />} />
+  </>
+);
+
+export default AdminRoutes;
+


### PR DESCRIPTION
## Summary
- create `AdminRoutes` component to house routes under `/admin`
- simplify `App.tsx` by using the new modularized routes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden from registry.npmjs.org)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f57e3b388322ba6d3a1d7232d2ee