### PR TITLE
feat: add undo deletion hook

### DIFF
--- a/src/components/mapa-testemunhas/ProcessoTable.tsx
+++ b/src/components/mapa-testemunhas/ProcessoTable.tsx
@@ -7,17 +7,28 @@ import { ArrayField } from "./ArrayField";
 import { useMapaTestemunhasStore } from "@/lib/store/mapa-testemunhas";
 import { applyPIIMask } from "@/utils/pii-mask";
 import { RiskBadge } from "@/components/RiskBadge";
+import { useUndoDelete } from "@/hooks/useUndoDelete";
 
 interface ProcessoTableProps {
   data: PorProcesso[];
 }
 
 export function ProcessoTable({ data }: ProcessoTableProps) {
-  const { setSelectedProcesso, setIsDetailDrawerOpen, isPiiMasked } = useMapaTestemunhasStore();
+  const { setSelectedProcesso, setIsDetailDrawerOpen, isPiiMasked, removeProcesso, restoreProcesso } = useMapaTestemunhasStore();
+  const { remove } = useUndoDelete<PorProcesso>('Processo');
 
   const handleViewDetail = (processo: PorProcesso) => {
     setSelectedProcesso(processo);
     setIsDetailDrawerOpen(true);
+  };
+
+  const handleDelete = (processo: PorProcesso) => {
+    remove({
+      key: processo.cnj,
+      label: processo.cnj,
+      onDelete: () => removeProcesso(processo.cnj),
+      onRestore: restoreProcesso,
+    });
   };
 
   const getStatusColor = (status: string | null) => {
@@ -125,10 +136,11 @@ export function ProcessoTable({ data }: ProcessoTableProps) {
                   >
                     <Edit className="h-4 w-4" />
                   </Button>
-                  <Button 
-                    variant="ghost" 
+                  <Button
+                    variant="ghost"
                     size="sm"
                     className="h-8 w-8 p-0 text-destructive hover:text-destructive"
+                    onClick={() => handleDelete(processo)}
                   >
                     <Trash2 className="h-4 w-4" />
                   </Button>

--- a/src/components/mapa-testemunhas/TestemunhaTable.tsx
+++ b/src/components/mapa-testemunhas/TestemunhaTable.tsx
@@ -1,13 +1,13 @@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Eye, Edit, Trash2, CheckCircle, XCircle, Undo2 } from "lucide-react";
+import { Eye, Edit, Trash2, CheckCircle, XCircle } from "lucide-react";
 import { PorTestemunha } from "@/types/mapa-testemunhas";
 import { ArrayField } from "./ArrayField";
 import { useMapaTestemunhasStore } from "@/lib/store/mapa-testemunhas";
 import { applyPIIMask } from "@/utils/pii-mask";
 import { DataState, DataStatus } from "@/components/ui/data-state";
-import { useToast } from "@/hooks/use-toast";
+import { useUndoDelete } from "@/hooks/useUndoDelete";
 
 interface TestemunhaTableProps {
   data: PorTestemunha[];
@@ -17,7 +17,7 @@ interface TestemunhaTableProps {
 
 export function TestemunhaTable({ data, status, onRetry }: TestemunhaTableProps) {
   const { setSelectedTestemunha, setIsDetailDrawerOpen, isPiiMasked, removeTestemunha, restoreTestemunha } = useMapaTestemunhasStore();
-  const { toast } = useToast();
+  const { remove } = useUndoDelete<PorTestemunha>('Testemunha');
 
   const handleViewDetail = (testemunha: PorTestemunha) => {
     setSelectedTestemunha(testemunha);
@@ -51,30 +51,12 @@ export function TestemunhaTable({ data, status, onRetry }: TestemunhaTableProps)
   }
 
   const handleDelete = (t: PorTestemunha) => {
-    const removed = removeTestemunha(t.nome_testemunha);
-    const toastRes = toast({
-      title: "Testemunha removida",
-      description: (
-        <div className="flex items-center justify-between">
-          <span>{t.nome_testemunha}</span>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              if (removed) restoreTestemunha(removed);
-            }}
-            className="ml-2 h-6 px-2 text-xs"
-          >
-            <Undo2 className="h-3 w-3 mr-1" />
-            Desfazer
-          </Button>
-        </div>
-      ),
-      duration: 5000,
+    remove({
+      key: t.nome_testemunha,
+      label: t.nome_testemunha,
+      onDelete: () => removeTestemunha(t.nome_testemunha),
+      onRestore: restoreTestemunha,
     });
-
-    // ensure toast returns id to satisfy types (unused)
-    return toastRes;
   };
 
   return (

--- a/src/hooks/useUndoDelete.tsx
+++ b/src/hooks/useUndoDelete.tsx
@@ -1,0 +1,58 @@
+import { useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Undo2 } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+
+interface DeleteOptions<T> {
+  key: string; // unique identifier
+  label: string; // label to show in toast
+  onDelete: () => T | null; // perform deletion and return removed item
+  onRestore: (item: T) => void; // restore item if undo
+}
+
+export function useUndoDelete<T>(resource: string) {
+  const { toast } = useToast();
+  const queueRef = useRef(new Map<string, T>());
+
+  const remove = ({ key, label, onDelete, onRestore }: DeleteOptions<T>) => {
+    // Perform deletion
+    const removed = onDelete();
+    if (!removed) return; // nothing deleted
+
+    // Ensure idempotency: replace any existing pending action for the same key
+    queueRef.current.set(key, removed);
+
+    const undo = () => {
+      const original = queueRef.current.get(key);
+      if (!original) return; // already handled
+      onRestore(original);
+      queueRef.current.delete(key);
+    };
+
+    toast({
+      title: `${resource} removido`,
+      description: (
+        <div className="flex items-center justify-between">
+          <span>{label}</span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={undo}
+            className="ml-2 h-6 px-2 text-xs"
+          >
+            <Undo2 className="h-3 w-3 mr-1" />
+            Desfazer
+          </Button>
+        </div>
+      ),
+      duration: 5000,
+    });
+
+    // Remove from queue after timeout to finalize deletion
+    setTimeout(() => {
+      queueRef.current.delete(key);
+    }, 5000);
+  };
+
+  return { remove };
+}

--- a/src/lib/store/mapa-testemunhas.ts
+++ b/src/lib/store/mapa-testemunhas.ts
@@ -100,6 +100,8 @@ interface MapaTestemunhasStore {
   setTestemunhasPage: (page: number) => void;
   setTotalProcessos: (total: number) => void;
   setTotalTestemunhas: (total: number) => void;
+  removeProcesso: (cnj: string) => PorProcesso | null;
+  restoreProcesso: (processo: PorProcesso) => void;
   removeTestemunha: (nome: string) => PorTestemunha | null;
   restoreTestemunha: (testemunha: PorTestemunha) => void;
   resetFilters: () => void;
@@ -200,6 +202,20 @@ export const useMapaTestemunhasStore = create<MapaTestemunhasStore>((set, get) =
   setTestemunhasPage: (page) => set({ testemunhasPage: page }),
   setTotalProcessos: (total) => set({ totalProcessos: total }),
   setTotalTestemunhas: (total) => set({ totalTestemunhas: total }),
+  removeProcesso: (cnj) => {
+    let removed: PorProcesso | null = null;
+    set((state) => {
+      const index = state.processos.findIndex(p => p.cnj === cnj);
+      if (index === -1) return {} as any;
+      removed = state.processos[index];
+      const arr = [...state.processos];
+      arr.splice(index, 1);
+      return { processos: arr, totalProcessos: state.totalProcessos - 1 } as any;
+    });
+    return removed;
+  },
+  restoreProcesso: (processo) =>
+    set((state) => ({ processos: [processo, ...state.processos], totalProcessos: state.totalProcessos + 1 })),
   removeTestemunha: (nome) => {
     let removed: PorTestemunha | null = null;
     set((state) => {


### PR DESCRIPTION
## Summary
- add generic `useUndoDelete` hook to queue deletions and offer 5s undo
- wire hook into witness and process tables with restore handlers
- extend store with process remove/restore helpers

## Testing
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f8aae5748322ad96466e664ead01