### PR TITLE
feat: add analytics events tracking

### DIFF
--- a/src/middleware/consent.ts
+++ b/src/middleware/consent.ts
@@ -4,12 +4,14 @@ import { supabase } from '@/integrations/supabase/client';
 export const analyticsAllowed = async (): Promise<boolean> => {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return false;
-  // TODO: Re-enable when lgpd_consent table exists
-  // const { data } = await supabase
-  //   .from('lgpd_consent')
-  //   .select('analytics')
-  //   .eq('user_id', user.id)
-  //   .single();
-  // return !!data?.analytics;
-  return false; // Temporarily return false until table exists
+  const { data, error } = await supabase
+    .from('lgpd_consent')
+    .select('analytics')
+    .eq('user_id', user.id)
+    .single();
+  if (error) {
+    console.error('Error checking consent', error);
+    return false;
+  }
+  return !!data?.analytics;
 };

--- a/src/pages/admin/Metrics.tsx
+++ b/src/pages/admin/Metrics.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { analyticsAllowed } from '@/middleware/consent';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+interface SummaryRow {
+  event: string;
+  count: number;
+}
+
+const Metrics = () => {
+  const [start, setStart] = useState(() => new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10));
+  const [end, setEnd] = useState(() => new Date().toISOString().slice(0, 10));
+  const [rows, setRows] = useState<SummaryRow[]>([]);
+
+  const fetchData = async () => {
+    if (!(await analyticsAllowed())) return;
+    const { data, error } = await supabase.rpc('analytics_events_summary', {
+      start_ts: new Date(start).toISOString(),
+      end_ts: new Date(end).toISOString(),
+    });
+    if (!error && data) {
+      setRows(data as SummaryRow[]);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Metrics</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex gap-2 mb-4">
+          <Input type="date" value={start} onChange={(e) => setStart(e.target.value)} />
+          <Input type="date" value={end} onChange={(e) => setEnd(e.target.value)} />
+          <Button onClick={fetchData}>Refresh</Button>
+        </div>
+        <ul>
+          {rows.map((r) => (
+            <li key={r.event} className="py-1">{r.event}: {r.count}</li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default Metrics;

--- a/src/routes/AdminRoutes.tsx
+++ b/src/routes/AdminRoutes.tsx
@@ -18,6 +18,7 @@ const PromptStudio = lazy(() => import("@/pages/admin/openai/PromptStudio"));
 const OpenAIPlayground = lazy(() => import("@/pages/admin/openai/Playground"));
 const Logs = lazy(() => import("@/pages/admin/Logs"));
 const ValidationTest = lazy(() => import("@/pages/admin/ValidationTest"));
+const Metrics = lazy(() => import("@/pages/admin/Metrics"));
 
 // Data Explorer components
 const BaseRedirect = lazy(() => import("@/pages/admin/base/index"));
@@ -29,6 +30,7 @@ const AdminRoutes = () => (
   <>
     <Route path="/admin" element={<Dashboard />} />
     <Route path="/admin/analytics" element={<Analytics />} />
+    <Route path="/admin/metrics" element={<Metrics />} />
     <Route path="/admin/ia" element={<OpenAI />} />
     <Route path="/admin/ia/chaves" element={<OpenAIKeys />} />
     <Route path="/admin/ia/modelos" element={<OpenAIModels />} />

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,27 @@
+import { supabase } from '@/integrations/supabase/client';
+import { analyticsAllowed } from '@/middleware/consent';
+
+export type AnalyticsEvent =
+  | 'beta_signup'
+  | 'created_first_map'
+  | 'nps_score'
+  | string;
+
+/** Track analytics events respecting user consent */
+export const track = async (
+  event: AnalyticsEvent,
+  metadata: Record<string, any> = {}
+): Promise<void> => {
+  if (!(await analyticsAllowed())) return;
+  const { data: { user } } = await supabase.auth.getUser();
+  const userId = user?.id ?? null;
+  // Remove common PII fields from metadata
+  const sanitized = Object.fromEntries(
+    Object.entries(metadata).filter(([key]) => !['email', 'name'].includes(key))
+  );
+  await supabase.from('analytics_events').insert({
+    user_id: userId,
+    event,
+    metadata: sanitized,
+  });
+};

--- a/supabase/migrations/20251201000000_create_analytics_events.sql
+++ b/supabase/migrations/20251201000000_create_analytics_events.sql
@@ -1,0 +1,21 @@
+-- Create table for analytics events
+create table if not exists public.analytics_events (
+  id bigserial primary key,
+  user_id uuid references auth.users(id),
+  event text not null,
+  metadata jsonb,
+  ts timestamptz not null default timezone('utc', now())
+);
+
+-- Indexes to optimize queries
+create index if not exists analytics_events_ts_idx on public.analytics_events(ts);
+create index if not exists analytics_events_event_idx on public.analytics_events(event);
+
+-- Aggregate function to summarize events between two timestamps
+create or replace function public.analytics_events_summary(start_ts timestamptz, end_ts timestamptz)
+returns table(event text, count bigint) language sql stable as $$
+  select event, count(*)::bigint
+  from public.analytics_events
+  where ts between start_ts and end_ts
+  group by event;
+$$;

--- a/tests/analytics-events.test.ts
+++ b/tests/analytics-events.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import { config as loadEnv } from 'dotenv';
+
+loadEnv();
+
+const url = process.env.SUPABASE_URL as string | undefined;
+const key = process.env.SUPABASE_ANON_KEY as string | undefined;
+
+const supabase = url && key ? createClient(url, key) : null;
+
+describe('analytics_events', () => {
+  it('stores and aggregates events', async () => {
+    if (!supabase) {
+      console.warn('Skipping analytics_events test due to missing Supabase env vars');
+      return;
+    }
+
+    await supabase.from('analytics_events').insert([
+      { event: 'beta_signup', metadata: { source: 'test' } },
+      { event: 'created_first_map', metadata: { source: 'test' } },
+      { event: 'nps_score', metadata: { score: 9 } }
+    ]);
+
+    const start = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const end = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+    const { data, error } = await supabase.rpc('analytics_events_summary', {
+      start_ts: start,
+      end_ts: end
+    });
+    expect(error).toBeNull();
+    const counts = Object.fromEntries(
+      (data as any[]).map((row: any) => [row.event, row.count])
+    );
+    expect(counts.beta_signup).toBeGreaterThan(0);
+    expect(counts.created_first_map).toBeGreaterThan(0);
+    expect(counts.nps_score).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- create `analytics_events` table and aggregation function
- add front-end tracking utility and LGPD consent check
- include simple admin metrics page and integration test

## Testing
- `npm test tests/analytics-events.test.ts` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f8e7a09c8322b12f64d69d35914a