### PR TITLE
feat: add legal footer with policy links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import AuthGuard from "@/components/AuthGuard";
 import { AppLayout } from "@/components/navigation/AppLayout";
 import { ErrorBoundary } from "@/components/core/ErrorBoundary";
 import AdminRoutes from "./routes/AdminRoutes";
+import { FooterLegal } from "@/components/common/FooterLegal";
 
 const MapaPage = lazy(() => import("./pages/MapaPage"));
 const PublicHome = lazy(() => import("./pages/PublicHome"));
@@ -25,6 +26,9 @@ const NotFound = lazy(() => import("./pages/NotFound"));
 const DemoMapaTestemunhas = lazy(() => import("./pages/DemoMapaTestemunhas"));
 const TemplatePage = lazy(() => import("./pages/TemplatePage"));
 const ReportDemo = lazy(() => import("./pages/ReportDemo"));
+const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
+const TermsOfUse = lazy(() => import("./pages/TermsOfUse"));
+const LGPD = lazy(() => import("./pages/LGPD"));
 
 // React Query client configuration
 const queryClient = new QueryClient({
@@ -52,53 +56,61 @@ const App = () => (
                 v7_relativeSplatPath: true,
               }}
             >
-              <Suspense fallback={<div className="p-4">Carregando...</div>}>
-                <Routes>
-                  {/* Public routes */}
-                  <Route path="/" element={<PublicHome />} />
-                  <Route path="/sobre" element={<About />} />
-                  <Route path="/beta" element={<Beta />} />
-                  <Route path="/login" element={<Login />} />
-                  <Route path="/reset" element={<Reset />} />
-                  <Route path="/reset/confirm" element={<ResetConfirm />} />
-                  <Route path="/verify-otp" element={<VerifyOtp />} />
-                  <Route path="/portal-titular" element={<PortalTitular />} />
-                  <Route path="/import/template" element={<TemplatePage />} />
-                  <Route path="/demo/mapa-testemunhas" element={<DemoMapaTestemunhas />} />
+              <div className="min-h-screen flex flex-col">
+                <div className="flex-1">
+                  <Suspense fallback={<div className="p-4">Carregando...</div>}>
+                    <Routes>
+                      {/* Public routes */}
+                      <Route path="/" element={<PublicHome />} />
+                      <Route path="/sobre" element={<About />} />
+                      <Route path="/beta" element={<Beta />} />
+                      <Route path="/login" element={<Login />} />
+                      <Route path="/reset" element={<Reset />} />
+                      <Route path="/reset/confirm" element={<ResetConfirm />} />
+                      <Route path="/verify-otp" element={<VerifyOtp />} />
+                      <Route path="/portal-titular" element={<PortalTitular />} />
+                      <Route path="/import/template" element={<TemplatePage />} />
+                      <Route path="/demo/mapa-testemunhas" element={<DemoMapaTestemunhas />} />
+                      <Route path="/politica-de-privacidade" element={<PrivacyPolicy />} />
+                      <Route path="/termos-de-uso" element={<TermsOfUse />} />
+                      <Route path="/lgpd" element={<LGPD />} />
 
-                  {/* Protected routes with app layout */}
-                  <Route
-                    path="/*"
-                    element={
-                      <AuthGuard>
-                        <AppLayout>
-                          <ErrorBoundary>
-                            <Suspense fallback={<div className="p-4">Carregando...</div>}>
-                              <Routes>
-                                <Route path="/dashboard" element={<Navigate to="/mapa" replace />} />
-                                <Route path="/mapa" element={<MapaPage />} />
-                                <Route path="/mapa-testemunhas" element={<MapaPage />} />
-                                <Route path="/dados" element={<Navigate to="/mapa" replace />} />
-                                <Route path="/dados/mapa" element={<Navigate to="/mapa" replace />} />
-                                {/* Redirect deprecated chat route to mapa-testemunhas */}
-                                <Route path="/chat" element={<Navigate to="/mapa-testemunhas?view=chat" replace />} />
-                                <Route path="/app/chat" element={<Navigate to="/mapa-testemunhas?view=chat" replace />} />
+                      {/* Protected routes with app layout */}
+                      <Route
+                        path="/*"
+                        element={
+                          <AuthGuard>
+                            <AppLayout>
+                              <ErrorBoundary>
+                                <Suspense fallback={<div className="p-4">Carregando...</div>}>
+                                  <Routes>
+                                    <Route path="/dashboard" element={<Navigate to="/mapa" replace />} />
+                                    <Route path="/mapa" element={<MapaPage />} />
+                                    <Route path="/mapa-testemunhas" element={<MapaPage />} />
+                                    <Route path="/dados" element={<Navigate to="/mapa" replace />} />
+                                    <Route path="/dados/mapa" element={<Navigate to="/mapa" replace />} />
+                                    {/* Redirect deprecated chat route to mapa-testemunhas */}
+                                    <Route path="/chat" element={<Navigate to="/mapa-testemunhas?view=chat" replace />} />
+                                    <Route path="/app/chat" element={<Navigate to="/mapa-testemunhas?view=chat" replace />} />
 
-                                {/* Admin routes */}
-                                <AdminRoutes />
-                                <Route path="/import" element={<Navigate to="/admin/base-import" replace />} />
-                                <Route path="/relatorio" element={<ReportDemo />} />
+                                    {/* Admin routes */}
+                                    <AdminRoutes />
+                                    <Route path="/import" element={<Navigate to="/admin/base-import" replace />} />
+                                    <Route path="/relatorio" element={<ReportDemo />} />
 
-                                <Route path="*" element={<NotFound />} />
-                              </Routes>
-                            </Suspense>
-                          </ErrorBoundary>
-                        </AppLayout>
-                      </AuthGuard>
-                    }
-                  />
-                </Routes>
-              </Suspense>
+                                    <Route path="*" element={<NotFound />} />
+                                  </Routes>
+                                </Suspense>
+                              </ErrorBoundary>
+                            </AppLayout>
+                          </AuthGuard>
+                        }
+                      />
+                    </Routes>
+                  </Suspense>
+                </div>
+                <FooterLegal />
+              </div>
             </BrowserRouter>
           </ConsentProvider>
         </TooltipProvider>

--- a/src/components/common/FooterLegal.tsx
+++ b/src/components/common/FooterLegal.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export function FooterLegal() {
+  const linkClasses =
+    'text-sm text-foreground hover:text-primary underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+
+  return (
+    <footer className="bg-muted text-foreground py-4 border-t border-muted-foreground/20">
+      <div className="container mx-auto px-6">
+        <nav className="flex flex-wrap justify-center gap-6">
+          <Link to="/politica-de-privacidade" className={linkClasses}>
+            Política de Privacidade
+          </Link>
+          <Link to="/termos-de-uso" className={linkClasses}>
+            Termos de Uso
+          </Link>
+          <Link to="/lgpd" className={linkClasses}>
+            LGPD
+          </Link>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/src/pages/LGPD.tsx
+++ b/src/pages/LGPD.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function LGPD() {
+  return (
+    <main className="container mx-auto px-6 py-8">
+      <h1 className="text-2xl font-bold mb-4">LGPD</h1>
+      <p>Esta é a página sobre a LGPD.</p>
+    </main>
+  );
+}

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function PrivacyPolicy() {
+  return (
+    <main className="container mx-auto px-6 py-8">
+      <h1 className="text-2xl font-bold mb-4">Política de Privacidade</h1>
+      <p>Esta é a página de política de privacidade.</p>
+    </main>
+  );
+}

--- a/src/pages/TermsOfUse.tsx
+++ b/src/pages/TermsOfUse.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function TermsOfUse() {
+  return (
+    <main className="container mx-auto px-6 py-8">
+      <h1 className="text-2xl font-bold mb-4">Termos de Uso</h1>
+      <p>Esta é a página de termos de uso.</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add `FooterLegal` component with links to Privacy Policy, Terms of Use and LGPD pages
- expose legal pages and include footer across all routes

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c1fdcb97808322bbbd1da4d3447640