### PR TITLE
add data security page with LGPD practices

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ const NotFound = lazy(() => import("./pages/NotFound"));
 const DemoMapaTestemunhas = lazy(() => import("./pages/DemoMapaTestemunhas"));
 const TemplatePage = lazy(() => import("./pages/TemplatePage"));
 const ReportDemo = lazy(() => import("./pages/ReportDemo"));
+const Seguranca = lazy(() => import("./pages/Seguranca"));
 
 // React Query client configuration
 const queryClient = new QueryClient({
@@ -63,6 +64,7 @@ const App = () => (
                   <Route path="/reset/confirm" element={<ResetConfirm />} />
                   <Route path="/verify-otp" element={<VerifyOtp />} />
                   <Route path="/portal-titular" element={<PortalTitular />} />
+                  <Route path="/seguranca" element={<Seguranca />} />
                   <Route path="/import/template" element={<TemplatePage />} />
                   <Route path="/demo/mapa-testemunhas" element={<DemoMapaTestemunhas />} />
 

--- a/src/components/seguranca/DataHandlingSection.tsx
+++ b/src/components/seguranca/DataHandlingSection.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { EyeOff, History, Database, ShieldCheck } from 'lucide-react';
+
+interface Practice {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  bullets: string[];
+}
+
+const practices: Practice[] = [
+  {
+    icon: EyeOff,
+    title: 'Mascaramento de Dados',
+    bullets: [
+      'Informações sensíveis ocultas em telas e logs.',
+      'Anonimização em ambientes de teste.',
+    ],
+  },
+  {
+    icon: History,
+    title: 'Trilha de Auditoria',
+    bullets: [
+      'Registro de ações com timestamp e usuário.',
+      'Monitoramento contínuo para segurança.',
+    ],
+  },
+  {
+    icon: Database,
+    title: 'Minimização de Dados',
+    bullets: [
+      'Coletamos apenas o necessário para cada operação.',
+      'Retenção limitada e descarte automático.',
+    ],
+  },
+  {
+    icon: ShieldCheck,
+    title: 'Práticas de LGPD',
+    bullets: [
+      'Consentimento claro e revogável.',
+      'Portal do Titular para controle dos dados.',
+    ],
+  },
+];
+
+export function DataHandlingSection() {
+  return (
+    <section className="py-12 bg-muted/20">
+      <div className="container mx-auto px-6">
+        <h2 className="text-2xl font-semibold mb-8 text-center">
+          Como tratamos seus dados
+        </h2>
+        <ul className="space-y-8">
+          {practices.map((p, i) => (
+            <li key={i} className="flex gap-4">
+              <div className="flex-shrink-0 mt-1">
+                <p.icon className="w-6 h-6 text-primary" />
+              </div>
+              <div>
+                <h3 className="text-xl font-semibold mb-2">{p.title}</h3>
+                <ul className="list-disc ml-6 text-muted-foreground">
+                  {p.bullets.map((b, idx) => (
+                    <li key={idx}>{b}</li>
+                  ))}
+                </ul>
+              </div>
+            </li>
+          ))}
+        </ul>
+        <div className="mt-12 text-center">
+          <a href="/portal-titular" className="text-primary underline">
+            Acesse o Portal do Titular
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/seguranca/SegurancaHeader.tsx
+++ b/src/components/seguranca/SegurancaHeader.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export function SegurancaHeader() {
+  return (
+    <section className="py-16">
+      <div className="container mx-auto px-6 text-center">
+        <h1 className="text-3xl md:text-4xl font-bold mb-4">
+          Segurança & LGPD
+        </h1>
+        <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
+          Transparência em como protegemos e tratamos suas informações.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/site/Footer.tsx
+++ b/src/components/site/Footer.tsx
@@ -11,7 +11,7 @@ export function Footer() {
     { label: 'Privacidade / Gerenciar cookies', action: () => setOpen(true) },
     { label: 'Sobre o AssistJur.IA', action: () => navigate('/sobre') },
     { label: 'Sobre Bianca', action: () => navigate('/sobre') },
-    { label: 'Segurança & Conformidade', action: () => navigate('/sobre#seguranca') },
+    { label: 'Segurança de Dados', action: () => navigate('/seguranca') },
   ];
 
   return (

--- a/src/pages/Seguranca.tsx
+++ b/src/pages/Seguranca.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { SegurancaHeader } from '@/components/seguranca/SegurancaHeader';
+import { DataHandlingSection } from '@/components/seguranca/DataHandlingSection';
+import { Footer } from '@/components/site/Footer';
+
+export default function Seguranca() {
+  return (
+    <div className="min-h-screen bg-background">
+      <head>
+        <title>Segurança de Dados - AssistJur.IA</title>
+        <meta
+          name="description"
+          content="Mascaramento de dados, trilha de auditoria e práticas de LGPD no AssistJur.IA."
+        />
+      </head>
+      <SegurancaHeader />
+      <main>
+        <DataHandlingSection />
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/seguranca` route with modular sections on data masking, audit logs, data minimization and LGPD
- link security page in site footer

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fde988fc83228738a2992309e0d1