### PR TITLE
Add breadcrumb and back-to-top FAB to login page

### DIFF
--- a/src/components/site/BackToTopFAB.tsx
+++ b/src/components/site/BackToTopFAB.tsx
@@ -1,8 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { ArrowUp } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
-export function BackToTopFAB() {
+interface BackToTopFABProps {
+  className?: string;
+}
+
+export function BackToTopFAB({ className }: BackToTopFABProps) {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -25,7 +30,10 @@ export function BackToTopFAB() {
     <Button
       size="icon"
       aria-label="Voltar ao topo"
-      className="fixed bottom-6 right-6 rounded-full shadow-lg z-50"
+      className={cn(
+        'fixed bottom-6 right-6 rounded-full shadow-lg z-50',
+        className
+      )}
       onClick={scrollToTop}
     >
       <ArrowUp className="h-5 w-5" />

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { AuthCard } from '@/components/auth/AuthCard';
 import { OAuthButtons } from '@/components/auth/OAuthButtons';
@@ -12,6 +12,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { getDefaultRedirect, AUTH_CONFIG } from '@/config/auth';
 import heroImage from "@/assets/hero-legal-tech.jpg";
 import { BrandHeader } from '@/components/brand/BrandHeader';
+import { BackToTopFAB } from '@/components/site/BackToTopFAB';
 
 const Login = () => {
   const navigate = useNavigate();
@@ -50,13 +51,38 @@ const Login = () => {
     <div className="min-h-screen bg-gradient-subtle lg:grid lg:grid-cols-2">
       {/* SEO and Accessibility */}
       <div className="sr-only">
-        <h1>Login - AssistJur.IA</h1>
+        <h1 id="main-heading" tabIndex={-1}>Login - AssistJur.IA</h1>
         <p>Acesse sua conta do AssistJur.IA para análise avançada de testemunhas com conformidade LGPD</p>
       </div>
 
       {/* Left side - Form */}
       <div className="flex flex-col justify-center px-6 py-12 lg:px-8">
         <div className="mx-auto w-full max-w-md">
+          <nav aria-label="breadcrumb" className="mb-4 text-sm">
+            <ol className="flex items-center text-muted-foreground">
+              <li>
+                <Link
+                  to="/"
+                  className="text-primary hover:underline focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded-sm"
+                >
+                  AssistJur IA
+                </Link>
+              </li>
+              <li aria-hidden="true" className="mx-2">
+                ›
+              </li>
+              <li>
+                <Link
+                  to="/login"
+                  aria-current="page"
+                  className="focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded-sm"
+                >
+                  Login
+                </Link>
+              </li>
+            </ol>
+          </nav>
+
           {/* Logo */}
           <div className="flex items-center justify-center mb-8 lg:hidden">
             <BrandHeader size="lg" className="gap-3" />
@@ -197,6 +223,8 @@ const Login = () => {
           </footer>
         </div>
       </div>
+
+      <BackToTopFAB className="bottom-24" />
 
       {/* Right side - Hero (hidden on mobile) */}
       <aside className="hidden lg:block relative" role="complementary">


### PR DESCRIPTION
## Summary
- add accessible breadcrumb navigation to login page
- introduce reusable FAB for smooth scroll back to top focusing the main heading

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c2009d17108322ba7170a7dc3f5a8b