### PR TITLE
feat: add global service health banner with retry

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,8 @@ import { AppLayout } from "@/components/navigation/AppLayout";
 import { ErrorBoundary } from "@/components/core/ErrorBoundary";
 import AdminRoutes from "./routes/AdminRoutes";
 import { FooterLegal } from "@/components/common/FooterLegal";
+import { ServiceHealthProvider } from "@/hooks/useServiceHealth";
+import { StatusBanner } from "@/components/common/StatusBanner";
 
 const MapaPage = lazy(() => import("./pages/MapaPage"));
 const PublicHome = lazy(() => import("./pages/PublicHome"));
@@ -44,19 +46,21 @@ const queryClient = new QueryClient({
 const App = () => (
   <ErrorBoundary>
     <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <TooltipProvider>
-          <Toaster />
-          <Sonner />
-          <ConsentProvider>
-            <ConsentDialog />
-            <BrowserRouter
+      <ServiceHealthProvider>
+        <AuthProvider>
+          <TooltipProvider>
+            <Toaster />
+            <Sonner />
+            <ConsentProvider>
+              <ConsentDialog />
+              <BrowserRouter
               future={{
                 v7_startTransition: true,
                 v7_relativeSplatPath: true,
               }}
             >
               <div className="min-h-screen flex flex-col">
+                <StatusBanner />
                 <div className="flex-1">
                   <Suspense fallback={<div className="p-4">Carregando...</div>}>
                     <Routes>
@@ -113,8 +117,9 @@ const App = () => (
               </div>
             </BrowserRouter>
           </ConsentProvider>
-        </TooltipProvider>
-      </AuthProvider>
+          </TooltipProvider>
+        </AuthProvider>
+      </ServiceHealthProvider>
     </QueryClientProvider>
   </ErrorBoundary>
 );

--- a/src/components/common/StatusBanner.tsx
+++ b/src/components/common/StatusBanner.tsx
@@ -1,0 +1,27 @@
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { useServiceHealth } from '@/hooks/useServiceHealth';
+
+export function StatusBanner() {
+  const { isUnavailable, retry } = useServiceHealth();
+  if (!isUnavailable) return null;
+
+  return (
+    <Alert
+      variant="destructive"
+      role="alert"
+      className="rounded-none flex items-center justify-between"
+    >
+      <div>
+        <AlertTitle>Serviços indisponíveis</AlertTitle>
+        <AlertDescription>
+          Não foi possível conectar ao CNJ/Supabase.
+        </AlertDescription>
+      </div>
+      <Button variant="outline" onClick={retry} aria-label="Tentar novamente">
+        Tentar novamente
+      </Button>
+    </Alert>
+  );
+}
+

--- a/src/hooks/useServiceHealth.tsx
+++ b/src/hooks/useServiceHealth.tsx
@@ -1,0 +1,67 @@
+import { createContext, useContext, useRef, useState, ReactNode } from 'react';
+
+interface ServiceHealthContextValue {
+  execute<T>(action: () => Promise<T>): Promise<T>;
+  retry(): Promise<void>;
+  isUnavailable: boolean;
+}
+
+const ServiceHealthContext = createContext<ServiceHealthContextValue | undefined>(undefined);
+
+const INITIAL_BACKOFF = 1000; // 1s
+const MAX_BACKOFF = 8000; // 8s
+const CACHE_MS = 5000; // cache curto 5s
+
+export function ServiceHealthProvider({ children }: { children: ReactNode }) {
+  const [isUnavailable, setUnavailable] = useState(false);
+  const lastAction = useRef<(() => Promise<any>) | null>(null);
+  const lastAttempt = useRef(0);
+  const backoff = useRef(INITIAL_BACKOFF);
+
+  const execute = async <T,>(action: () => Promise<T>): Promise<T> => {
+    lastAction.current = action;
+    lastAttempt.current = Date.now();
+    try {
+      const result = await action();
+      setUnavailable(false);
+      backoff.current = INITIAL_BACKOFF;
+      return result;
+    } catch (err: any) {
+      if (err?.status >= 500 || err?.name === 'AbortError' || err?.message?.includes('Network')) {
+        setUnavailable(true);
+      }
+      throw err;
+    }
+  };
+
+  const retry = async () => {
+    if (!lastAction.current) return;
+
+    const now = Date.now();
+    if (now - lastAttempt.current < CACHE_MS) return;
+
+    await new Promise((res) => setTimeout(res, backoff.current));
+    backoff.current = Math.min(backoff.current * 2, MAX_BACKOFF);
+    lastAttempt.current = Date.now();
+    try {
+      await execute(lastAction.current);
+    } catch {
+      // keep banner visible on failure
+    }
+  };
+
+  return (
+    <ServiceHealthContext.Provider value={{ execute, retry, isUnavailable }}>
+      {children}
+    </ServiceHealthContext.Provider>
+  );
+}
+
+export function useServiceHealth() {
+  const ctx = useContext(ServiceHealthContext);
+  if (!ctx) {
+    throw new Error('useServiceHealth must be used within ServiceHealthProvider');
+  }
+  return ctx;
+}
+

--- a/src/tests/serviceHealthBanner.test.tsx
+++ b/src/tests/serviceHealthBanner.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ServiceHealthProvider, useServiceHealth } from '@/hooks/useServiceHealth';
+import { StatusBanner } from '@/components/common/StatusBanner';
+
+function TestComponent({ action }: { action: () => Promise<any> }) {
+  const { execute } = useServiceHealth();
+  return <button onClick={() => execute(action)}>run</button>;
+}
+
+describe('StatusBanner', () => {
+  it('shows banner on failure and retries action', async () => {
+    const action = vi
+      .fn<[], Promise<any>>()
+      .mockRejectedValueOnce(Object.assign(new Error('fail'), { status: 500 }))
+      .mockResolvedValueOnce('ok');
+
+    render(
+      <ServiceHealthProvider>
+        <StatusBanner />
+        <TestComponent action={action} />
+      </ServiceHealthProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /run/i }));
+    expect(await screen.findByText(/Serviços indisponíveis/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /tentar novamente/i }));
+
+    await waitFor(() => expect(action).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(screen.queryByText(/Serviços indisponíveis/i)).not.toBeInTheDocument()
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add ServiceHealthProvider with short cache and exponential backoff
- display global StatusBanner with retry for CNJ/Supabase outages
- cover retry flow with service health banner test

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c200f471ec8322b22467cf35549c45