### PR TITLE
feat(auth): optional TOTP 2FA with magic link login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ const ReportDemo = lazy(() => import("./pages/ReportDemo"));
 const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
 const TermsOfUse = lazy(() => import("./pages/TermsOfUse"));
 const LGPD = lazy(() => import("./pages/LGPD"));
+const TwoFactorSetup = lazy(() => import("./pages/TwoFactorSetup"));
 
 // React Query client configuration
 const queryClient = new QueryClient({
@@ -101,6 +102,7 @@ const App = () => (
                                     <AdminRoutes />
                                     <Route path="/import" element={<Navigate to="/admin/base-import" replace />} />
                                     <Route path="/relatorio" element={<ReportDemo />} />
+                                    <Route path="/account/2fa" element={<TwoFactorSetup />} />
 
                                     <Route path="*" element={<NotFound />} />
                                   </Routes>

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -26,6 +26,12 @@ const AuthGuard: React.FC<AuthGuardProps> = ({
         return;
       }
 
+      if (profile.two_factor_enabled && sessionStorage.getItem('mfa_verified') !== 'true') {
+        const nextPath = window.location.pathname + window.location.search;
+        navigate(`/verify-otp?next=${encodeURIComponent(nextPath)}`);
+        return;
+      }
+
       // Account not active
       if (!profile.is_active) {
         toast({

--- a/src/components/auth/TwoFactorForm.tsx
+++ b/src/components/auth/TwoFactorForm.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ShieldCheck, ArrowLeft, Loader2 } from "lucide-react";
 import { toast } from "sonner";
+import { verifyTOTP } from "@/utils/totp";
 
 const twoFactorSchema = z.object({
   code: z.string()
@@ -20,9 +21,11 @@ interface TwoFactorFormProps {
   onBack: () => void;
   onSuccess: () => void;
   userEmail?: string;
+  secret: string;
+  backupCode?: string;
 }
 
-export const TwoFactorForm = ({ onBack, onSuccess, userEmail }: TwoFactorFormProps) => {
+export const TwoFactorForm = ({ onBack, onSuccess, userEmail, secret, backupCode }: TwoFactorFormProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const [attempts, setAttempts] = useState(0);
 
@@ -37,11 +40,8 @@ export const TwoFactorForm = ({ onBack, onSuccess, userEmail }: TwoFactorFormPro
     setIsLoading(true);
     
     try {
-      // Mock 2FA verification
-      // In production, this would call Supabase MFA verify
-      
-      // Mock: accept 123456 as valid code
-      if (data.code === '123456') {
+      const isValid = verifyTOTP(data.code, secret) || (backupCode && data.code === backupCode);
+      if (isValid) {
         toast.success("Verificação concluída!", {
           description: "Acesso autorizado com sucesso."
         });
@@ -69,13 +69,6 @@ export const TwoFactorForm = ({ onBack, onSuccess, userEmail }: TwoFactorFormPro
     } finally {
       setIsLoading(false);
     }
-  };
-
-  const handleResendCode = async () => {
-    // Mock resend
-    toast.success("Novo código enviado", {
-      description: "Verifique seu aplicativo autenticador."
-    });
   };
 
   const formatCodeInput = (value: string) => {
@@ -145,17 +138,7 @@ export const TwoFactorForm = ({ onBack, onSuccess, userEmail }: TwoFactorFormPro
             )}
           </Button>
 
-          <div className="grid grid-cols-2 gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={handleResendCode}
-              disabled={isLoading}
-              className="text-xs"
-            >
-              Reenviar código
-            </Button>
-            
+          <div className="flex justify-center">
             <Button
               type="button"
               variant="ghost"
@@ -171,26 +154,8 @@ export const TwoFactorForm = ({ onBack, onSuccess, userEmail }: TwoFactorFormPro
       </form>
 
       {/* Help text */}
-      <div className="text-center space-y-2">
-        <div className="text-xs text-muted-foreground">
-          <p>Não consegue acessar seu autenticador?</p>
-          <button 
-            type="button"
-            className="text-primary hover:underline"
-            onClick={() => {
-              toast.info("Suporte disponível", {
-                description: "Entre em contato com o administrador do sistema."
-              });
-            }}
-          >
-            Entrar em contato com suporte
-          </button>
-        </div>
-        
-        {/* Mock hint for demo */}
-        <div className="text-xs bg-muted/30 p-2 rounded border">
-          <strong>Demo:</strong> Use o código <code className="font-mono">123456</code> para testar
-        </div>
+      <div className="text-center text-xs text-muted-foreground">
+        <p>Não consegue acessar seu autenticador? Utilize o código de backup fornecido ao habilitar o 2FA.</p>
       </div>
     </div>
   );

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -20,6 +20,9 @@ export interface UserProfile {
   updated_at: string;
   last_login_at?: string | null;
   data_access_level: 'FULL' | 'MASKED' | 'NONE';
+  two_factor_enabled?: boolean;
+  two_factor_secret?: string | null;
+  two_factor_backup_code?: string | null;
 }
 
 interface AuthContextType {
@@ -395,6 +398,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setUser(null);
       setProfile(null);
       setSession(null);
+      sessionStorage.removeItem('mfa_verified');
     } catch (error) {
       console.error('Error signing out:', error);
     }

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -958,6 +958,9 @@ export type Database = {
           organization_id: string | null
           role: Database["public"]["Enums"]["user_role"]
           terms_accepted_at: string | null
+          two_factor_enabled: boolean | null
+          two_factor_secret: string | null
+          two_factor_backup_code: string | null
           updated_at: string
           user_id: string
         }
@@ -973,6 +976,9 @@ export type Database = {
           organization_id?: string | null
           role?: Database["public"]["Enums"]["user_role"]
           terms_accepted_at?: string | null
+          two_factor_enabled?: boolean | null
+          two_factor_secret?: string | null
+          two_factor_backup_code?: string | null
           updated_at?: string
           user_id: string
         }
@@ -988,6 +994,9 @@ export type Database = {
           organization_id?: string | null
           role?: Database["public"]["Enums"]["user_role"]
           terms_accepted_at?: string | null
+          two_factor_enabled?: boolean | null
+          two_factor_secret?: string | null
+          two_factor_backup_code?: string | null
           updated_at?: string
           user_id?: string
         }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -28,11 +28,18 @@ const Login = () => {
 
   // Redirect if already authenticated
   useEffect(() => {
-    if (user) {
-      const redirectTo = getDefaultRedirect(profile?.role, next);
-      navigate(redirectTo);
+    if (user && profile) {
+      if (profile.two_factor_enabled && sessionStorage.getItem('mfa_verified') !== 'true') {
+        const params = new URLSearchParams();
+        params.set('email', user.email ?? '');
+        if (next) params.set('next', next);
+        navigate(`/verify-otp?${params.toString()}`);
+      } else {
+        const redirectTo = getDefaultRedirect(profile.role, next);
+        navigate(redirectTo);
+      }
     }
-  }, [user, profile?.role, navigate, next]);
+  }, [user, profile, navigate, next]);
 
   const handleForgotPassword = () => {
     navigate('/reset');

--- a/src/pages/TwoFactorSetup.tsx
+++ b/src/pages/TwoFactorSetup.tsx
@@ -1,0 +1,106 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthCard } from '@/components/auth/AuthCard';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useAuth } from '@/hooks/useAuth';
+import { generateSecret, generateBackupCode, generateOtpAuthUrl, verifyTOTP } from '@/utils/totp';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+
+const TwoFactorSetup = () => {
+  const { profile } = useAuth();
+  const navigate = useNavigate();
+  const [secret, setSecret] = useState('');
+  const [backupCode, setBackupCode] = useState('');
+  const [qrUrl, setQrUrl] = useState('');
+  const [code, setCode] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (profile) {
+      const newSecret = generateSecret();
+      setSecret(newSecret);
+      const bc = generateBackupCode();
+      setBackupCode(bc);
+      const url = generateOtpAuthUrl(profile.email, 'AssistJur', newSecret);
+      setQrUrl(`https://api.qrserver.com/v1/create-qr-code/?data=${encodeURIComponent(url)}`);
+    }
+  }, [profile]);
+
+  const handleEnable = async () => {
+    if (!profile) return;
+    setIsLoading(true);
+    try {
+      const valid = verifyTOTP(code, secret);
+      if (!valid) {
+        toast.error('Código inválido');
+        setIsLoading(false);
+        return;
+      }
+      const { error } = await supabase.from('profiles').update({
+        two_factor_enabled: true,
+        two_factor_secret: secret,
+        two_factor_backup_code: backupCode,
+      }).eq('id', profile.id);
+      if (error) throw error;
+      sessionStorage.setItem('mfa_verified', 'true');
+      toast.success('2FA habilitado');
+      navigate('/dados/mapa');
+    } catch (err) {
+      console.error('Enable 2FA error:', err);
+      toast.error('Erro ao habilitar 2FA');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (!profile) return null;
+
+  return (
+    <div className="min-h-screen bg-gradient-subtle flex flex-col justify-center px-6 py-12">
+      <div className="mx-auto w-full max-w-md">
+        <AuthCard
+          title="Ativar verificação em duas etapas"
+          description="Use um aplicativo autenticador"
+        >
+          <div className="space-y-4">
+            {qrUrl && <img src={qrUrl} alt="QR code" className="mx-auto" />}
+            <div className="text-sm text-center">
+              <p>
+                Escaneie o QR code ou use o código:
+                <code className="font-mono ml-1">{secret}</code>
+              </p>
+            </div>
+            <div className="text-sm text-center">
+              <p>
+                Guarde seu código de backup:
+                <code className="font-mono ml-1">{backupCode}</code>
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="code">Código do aplicativo</Label>
+              <Input
+                id="code"
+                value={code}
+                onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                placeholder="000000"
+                autoComplete="one-time-code"
+              />
+            </div>
+            <Button
+              className="w-full"
+              onClick={handleEnable}
+              disabled={isLoading || code.length !== 6}
+            >
+              {isLoading ? 'Verificando...' : 'Ativar 2FA'}
+            </Button>
+          </div>
+        </AuthCard>
+      </div>
+    </div>
+  );
+};
+
+export default TwoFactorSetup;

--- a/src/utils/totp.ts
+++ b/src/utils/totp.ts
@@ -1,0 +1,58 @@
+import { createHmac, randomBytes } from 'crypto';
+
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+export function generateSecret(length = 20): string {
+  const bytes = randomBytes(length);
+  let secret = '';
+  for (let i = 0; i < bytes.length; i++) {
+    secret += ALPHABET[bytes[i] % ALPHABET.length];
+  }
+  return secret;
+}
+
+function base32ToBuffer(base32: string): Buffer {
+  let bits = '';
+  const cleaned = base32.replace(/=+$/g, '').toUpperCase();
+  for (const char of cleaned) {
+    const val = ALPHABET.indexOf(char);
+    if (val === -1) continue;
+    bits += val.toString(2).padStart(5, '0');
+  }
+  const bytes = [];
+  for (let i = 0; i + 8 <= bits.length; i += 8) {
+    bytes.push(parseInt(bits.substring(i, i + 8), 2));
+  }
+  return Buffer.from(bytes);
+}
+
+export function generateTOTP(secret: string, step = 30, digits = 6, time = Date.now()): string {
+  const key = base32ToBuffer(secret);
+  const counter = Math.floor(time / 1000 / step);
+  const buffer = Buffer.alloc(8);
+  buffer.writeUInt32BE(Math.floor(counter / 0x100000000), 0);
+  buffer.writeUInt32BE(counter % 0x100000000, 4);
+  const hmac = createHmac('sha1', key).update(buffer).digest();
+  const offset = hmac[hmac.length - 1] & 0xf;
+  const code = (hmac.readUInt32BE(offset) & 0x7fffffff) % 10 ** digits;
+  return code.toString().padStart(digits, '0');
+}
+
+export function verifyTOTP(token: string, secret: string, window = 1, step = 30, digits = 6): boolean {
+  const now = Date.now();
+  for (let errorWindow = -window; errorWindow <= window; errorWindow++) {
+    const time = now + errorWindow * step * 1000;
+    if (generateTOTP(secret, step, digits, time) === token) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function generateBackupCode(): string {
+  return randomBytes(4).toString('hex').toUpperCase();
+}
+
+export function generateOtpAuthUrl(email: string, issuer: string, secret: string): string {
+  return `otpauth://totp/${encodeURIComponent(issuer)}:${encodeURIComponent(email)}?secret=${secret}&issuer=${encodeURIComponent(issuer)}`;
+}


### PR DESCRIPTION
## Summary
- implement TOTP utilities and two-factor setup screen
- verify login with authenticator code or backup code
- enforce second factor on login when enabled

## Testing
- `npm test` *(fails: vitest not found; dependencies blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68c2052409048322bb3734e2dbb88e15