### PR TITLE
feat: add team-based sharing with RLS

### DIFF
--- a/supabase/migrations/20251102120000_sharing_rls.sql
+++ b/supabase/migrations/20251102120000_sharing_rls.sql
@@ -1,0 +1,143 @@
+-- ============================================================================
+-- Migration: Document sharing with row level security
+-- Adds memberships, documents, shares tables, secure view and grant_access RPC
+-- ============================================================================
+
+-- 1. memberships table (user -> tenant mapping)
+CREATE TABLE IF NOT EXISTS public.memberships (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  role text DEFAULT 'member',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(tenant_id, user_id)
+);
+
+-- 2. documents table (tenant isolated resources)
+CREATE TABLE IF NOT EXISTS public.documents (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL,
+  owner_id uuid NOT NULL,
+  content text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 3. shares table (explicit access grants)
+CREATE TABLE IF NOT EXISTS public.shares (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id uuid NOT NULL REFERENCES public.documents(id) ON DELETE CASCADE,
+  member_id uuid NOT NULL REFERENCES public.memberships(id) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(document_id, member_id)
+);
+
+-- Enable RLS
+ALTER TABLE public.memberships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.documents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.shares ENABLE ROW LEVEL SECURITY;
+
+-- Default deny policies
+CREATE POLICY IF NOT EXISTS default_memberships ON public.memberships FOR ALL TO public USING (false);
+CREATE POLICY IF NOT EXISTS default_documents ON public.documents FOR ALL TO public USING (false);
+CREATE POLICY IF NOT EXISTS default_shares ON public.shares FOR ALL TO public USING (false);
+
+-- memberships: users can view their own membership
+CREATE POLICY IF NOT EXISTS memberships_self_access ON public.memberships
+  FOR SELECT TO authenticated
+  USING (auth.uid() = user_id);
+
+-- documents policies
+CREATE POLICY IF NOT EXISTS documents_owner_insert ON public.documents
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    auth.uid() IS NOT NULL AND
+    owner_id = auth.uid() AND
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+  );
+
+CREATE POLICY IF NOT EXISTS documents_owner_modify ON public.documents
+  FOR UPDATE TO authenticated
+  USING (
+    auth.uid() IS NOT NULL AND
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid AND
+    owner_id = auth.uid()
+  )
+  WITH CHECK (
+    auth.uid() IS NOT NULL AND
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid AND
+    owner_id = auth.uid()
+  );
+
+CREATE POLICY IF NOT EXISTS documents_owner_delete ON public.documents
+  FOR DELETE TO authenticated
+  USING (
+    auth.uid() IS NOT NULL AND
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid AND
+    owner_id = auth.uid()
+  );
+
+CREATE POLICY IF NOT EXISTS documents_access ON public.documents
+  FOR SELECT TO authenticated
+  USING (
+    auth.uid() IS NOT NULL AND
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid AND
+    (
+      owner_id = auth.uid() OR
+      EXISTS (
+        SELECT 1 FROM public.shares s
+        JOIN public.memberships m ON m.id = s.member_id
+        WHERE s.document_id = public.documents.id
+          AND m.user_id = auth.uid()
+      )
+    )
+  );
+
+-- shares policies
+CREATE POLICY IF NOT EXISTS shares_member_access ON public.shares
+  FOR SELECT TO authenticated
+  USING (
+    auth.uid() IS NOT NULL AND EXISTS (
+      SELECT 1 FROM public.memberships m
+      WHERE m.id = member_id AND m.user_id = auth.uid()
+    )
+  );
+
+-- Secure view exposing documents with RLS
+CREATE OR REPLACE VIEW public.v_documents_secure AS
+  SELECT id, tenant_id, owner_id, content, created_at
+  FROM public.documents;
+
+ALTER VIEW public.v_documents_secure SET (security_invoker = true);
+
+-- RPC: grant access to a membership
+CREATE OR REPLACE FUNCTION public.grant_access(p_document_id uuid, p_member_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant uuid;
+  v_owner uuid;
+BEGIN
+  v_tenant := (auth.jwt() ->> 'tenant_id')::uuid;
+  v_owner := auth.uid();
+
+  -- Ensure the caller owns the document within their tenant
+  IF NOT EXISTS (
+    SELECT 1 FROM public.documents d
+    WHERE d.id = p_document_id AND d.tenant_id = v_tenant AND d.owner_id = v_owner
+  ) THEN
+    RAISE EXCEPTION 'not authorized';
+  END IF;
+
+  INSERT INTO public.shares (document_id, member_id)
+  VALUES (p_document_id, p_member_id)
+  ON CONFLICT (document_id, member_id) DO NOTHING;
+END;
+$$;
+
+-- Indexes for quick lookups
+CREATE INDEX IF NOT EXISTS idx_documents_tenant_owner ON public.documents (tenant_id, owner_id);
+CREATE INDEX IF NOT EXISTS idx_shares_document ON public.shares (document_id, member_id);
+-- ============================================================================

--- a/supabase/tests/document_sharing.sql
+++ b/supabase/tests/document_sharing.sql
@@ -1,0 +1,41 @@
+-- pgTAP tests for document sharing RLS
+BEGIN;
+SELECT plan(2);
+
+-- Prepare sample users and tenant
+SELECT gen_random_uuid() AS user_a \gset
+SELECT gen_random_uuid() AS user_b \gset
+SELECT gen_random_uuid() AS tenant \gset
+SELECT gen_random_uuid() AS member_a \gset
+SELECT gen_random_uuid() AS member_b \gset
+
+-- Create memberships for users
+INSERT INTO public.memberships(id, tenant_id, user_id)
+VALUES (:'member_a', :'tenant', :'user_a'),
+       (:'member_b', :'tenant', :'user_b');
+
+-- User A context
+SELECT set_config('request.jwt.claim.sub', :'user_a', true);
+SELECT set_config('request.jwt.claim.tenant_id', :'tenant', true);
+
+INSERT INTO public.documents(tenant_id, owner_id, content)
+VALUES (:'tenant', :'user_a', 'segredo')
+RETURNING id \gset
+
+-- User B should not see the document before share
+SELECT set_config('request.jwt.claim.sub', :'user_b', true);
+SELECT set_config('request.jwt.claim.tenant_id', :'tenant', true);
+SELECT is( (SELECT count(*) FROM public.documents WHERE id = :'id'), 0, 'B cannot see before share');
+
+-- Grant access to B's membership
+SELECT set_config('request.jwt.claim.sub', :'user_a', true);
+SELECT set_config('request.jwt.claim.tenant_id', :'tenant', true);
+SELECT grant_access(:'id', :'member_b');
+
+-- User B should see the document after share
+SELECT set_config('request.jwt.claim.sub', :'user_b', true);
+SELECT set_config('request.jwt.claim.tenant_id', :'tenant', true);
+SELECT is( (SELECT count(*) FROM public.documents WHERE id = :'id'), 1, 'B can see after share');
+
+SELECT finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary
- add memberships, documents and shares tables with row-level security
- create grant_access RPC and secure view for documents
- add pgTAP test verifying shared access behavior

## Testing
- `pg_prove supabase/tests/document_sharing.sql` *(fails: command not found)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c205591f708322aa1e2a3a5c31be62