### PR TITLE
feat: add per-user feature flags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { FooterLegal } from "@/components/common/FooterLegal";
 import { ServiceHealthProvider } from "@/hooks/useServiceHealth";
 import { StatusBanner } from "@/components/common/StatusBanner";
 import SessionExpiredModal from "@/components/auth/SessionExpiredModal";
+import FeatureFlagGuard from "@/components/FeatureFlagGuard";
 
 const MapaPage = lazy(() => import("./pages/MapaPage"));
 const PublicHome = lazy(() => import("./pages/PublicHome"));
@@ -103,7 +104,14 @@ const App = () => (
                                     {/* Admin routes */}
                                     <AdminRoutes />
                                     <Route path="/import" element={<Navigate to="/admin/base-import" replace />} />
-                                    <Route path="/relatorio" element={<ReportDemo />} />
+                                    <Route
+                                      path="/relatorio"
+                                      element={
+                                        <FeatureFlagGuard flag="advanced-report">
+                                          <ReportDemo />
+                                        </FeatureFlagGuard>
+                                      }
+                                    />
                                     <Route path="/account/2fa" element={<TwoFactorSetup />} />
 
                                     <Route path="*" element={<NotFound />} />

--- a/src/components/FeatureFlagGuard.tsx
+++ b/src/components/FeatureFlagGuard.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+
+interface Props {
+  flag: string;
+  children: React.ReactNode;
+}
+
+export const FeatureFlagGuard: React.FC<Props> = ({ flag, children }) => {
+  const enabled = useFeatureFlag(flag);
+  if (!enabled) return null;
+  return <>{children}</>;
+};
+
+export default FeatureFlagGuard;

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -23,6 +23,7 @@ export interface UserProfile {
   two_factor_enabled?: boolean;
   two_factor_secret?: string | null;
   two_factor_backup_code?: string | null;
+  plan?: string;
 }
 
 interface AuthContextType {

--- a/src/hooks/useFeatureFlag.ts
+++ b/src/hooks/useFeatureFlag.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/hooks/useAuth';
+
+const CACHE_KEY = 'featureFlags';
+
+async function loadFlags(userId?: string, plan?: string) {
+  if (!userId && !plan) return;
+  const filters: string[] = [];
+  if (userId) filters.push(`user_id.eq.${userId}`);
+  if (plan) filters.push(`plan.eq.${plan}`);
+  const { data } = await supabase
+    .from('feature_flags')
+    .select('flag, enabled')
+    .or(filters.join(','));
+  const map: Record<string, boolean> = {};
+  data?.forEach((row) => {
+    map[row.flag] = row.enabled;
+  });
+  localStorage.setItem(CACHE_KEY, JSON.stringify(map));
+  window.dispatchEvent(new StorageEvent('storage', { key: CACHE_KEY }));
+}
+
+export const useFeatureFlag = (flag: string) => {
+  const { user, profile } = useAuth();
+  const [enabled, setEnabled] = useState<boolean>(() => {
+    const flags = JSON.parse(localStorage.getItem(CACHE_KEY) || '{}');
+    return !!flags[flag];
+  });
+
+  useEffect(() => {
+    loadFlags(user?.id, profile?.plan || undefined);
+  }, [user?.id, profile?.plan]);
+
+  useEffect(() => {
+    const handler = () => {
+      const flags = JSON.parse(localStorage.getItem(CACHE_KEY) || '{}');
+      setEnabled(!!flags[flag]);
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, [flag]);
+
+  return enabled;
+};
+
+export { loadFlags as refreshFeatureFlags };

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -957,6 +957,7 @@ export type Database = {
           last_login_at: string | null
           organization_id: string | null
           role: Database["public"]["Enums"]["user_role"]
+          plan: string | null
           terms_accepted_at: string | null
           two_factor_enabled: boolean | null
           two_factor_secret: string | null
@@ -975,6 +976,7 @@ export type Database = {
           last_login_at?: string | null
           organization_id?: string | null
           role?: Database["public"]["Enums"]["user_role"]
+          plan?: string | null
           terms_accepted_at?: string | null
           two_factor_enabled?: boolean | null
           two_factor_secret?: string | null
@@ -993,6 +995,7 @@ export type Database = {
           last_login_at?: string | null
           organization_id?: string | null
           role?: Database["public"]["Enums"]["user_role"]
+          plan?: string | null
           terms_accepted_at?: string | null
           two_factor_enabled?: boolean | null
           two_factor_secret?: string | null

--- a/supabase/migrations/20251203000000_create_feature_flags.sql
+++ b/supabase/migrations/20251203000000_create_feature_flags.sql
@@ -1,0 +1,23 @@
+-- Add subscription plan to profiles
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS plan text DEFAULT 'free';
+
+-- Table to store feature flags per user or plan
+CREATE TABLE IF NOT EXISTS public.feature_flags (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  flag text NOT NULL,
+  user_id uuid REFERENCES auth.users(id),
+  plan text,
+  enabled boolean NOT NULL DEFAULT false,
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  CONSTRAINT user_or_plan CHECK ((user_id IS NOT NULL) OR (plan IS NOT NULL))
+);
+
+-- Ensure uniqueness for user-level flags
+CREATE UNIQUE INDEX IF NOT EXISTS feature_flags_user_flag_idx
+  ON public.feature_flags(user_id, flag)
+  WHERE user_id IS NOT NULL;
+
+-- Ensure uniqueness for plan-level flags
+CREATE UNIQUE INDEX IF NOT EXISTS feature_flags_plan_flag_idx
+  ON public.feature_flags(plan, flag)
+  WHERE plan IS NOT NULL;

--- a/tests/feature-flags.test.tsx
+++ b/tests/feature-flags.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, act } from 'vitest';
+import FeatureFlagGuard from '@/components/FeatureFlagGuard';
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: '1' }, profile: { plan: 'free' } })
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({
+        or: () => Promise.resolve({ data: [] })
+      })
+    })
+  }
+}));
+
+describe('FeatureFlagGuard', () => {
+  it('toggles visibility when flag changes', async () => {
+    localStorage.setItem('featureFlags', JSON.stringify({ 'advanced-report': true }));
+    const { rerender } = render(
+      <FeatureFlagGuard flag="advanced-report"><div>Secret</div></FeatureFlagGuard>
+    );
+    expect(screen.getByText('Secret')).toBeInTheDocument();
+
+    await act(async () => {
+      localStorage.setItem('featureFlags', JSON.stringify({ 'advanced-report': false }));
+      window.dispatchEvent(new StorageEvent('storage', { key: 'featureFlags' }));
+    });
+    rerender(
+      <FeatureFlagGuard flag="advanced-report"><div>Secret</div></FeatureFlagGuard>
+    );
+    expect(screen.queryByText('Secret')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add feature flag table with user/plan scopes
- implement feature flag hook with local cache and guard component
- protect advanced report route behind feature flag

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c20976aeb88322aef9425df7eeba7b