### PR TITLE
feat: add accessible error pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
 const TermsOfUse = lazy(() => import("./pages/TermsOfUse"));
 const LGPD = lazy(() => import("./pages/LGPD"));
 const TwoFactorSetup = lazy(() => import("./pages/TwoFactorSetup"));
+const ServerError = lazy(() => import("./pages/ServerError"));
 
 // React Query client configuration
 const queryClient = new QueryClient({
@@ -81,6 +82,7 @@ const App = () => (
                       <Route path="/politica-de-privacidade" element={<PrivacyPolicy />} />
                       <Route path="/termos-de-uso" element={<TermsOfUse />} />
                       <Route path="/lgpd" element={<LGPD />} />
+                      <Route path="/500" element={<ServerError />} />
 
                       {/* Protected routes with app layout */}
                       <Route

--- a/src/components/core/ErrorBoundary.tsx
+++ b/src/components/core/ErrorBoundary.tsx
@@ -1,7 +1,5 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { AlertTriangle, RefreshCw, Home } from 'lucide-react';
+import ServerError from '@/pages/ServerError';
 
 interface Props {
   children: ReactNode;
@@ -53,10 +51,6 @@ export class ErrorBoundary extends Component<Props, State> {
     this.setState({ hasError: false, error: undefined, errorInfo: undefined });
   };
 
-  handleGoHome = () => {
-    window.location.href = '/';
-  };
-
   render() {
     if (this.state.hasError) {
       // Custom fallback UI
@@ -64,56 +58,7 @@ export class ErrorBoundary extends Component<Props, State> {
         return this.props.fallback;
       }
 
-      return (
-        <div className="min-h-screen flex items-center justify-center p-4 bg-gradient-subtle">
-          <Card className="w-full max-w-md">
-            <CardHeader className="text-center">
-              <div className="mx-auto w-12 h-12 bg-destructive/10 rounded-full flex items-center justify-center mb-4">
-                <AlertTriangle className="w-6 h-6 text-destructive" />
-              </div>
-              <CardTitle className="text-destructive">Algo deu errado</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <p className="text-sm text-muted-foreground text-center">
-                Ocorreu um erro inesperado na aplicação. Nossa equipe foi notificada.
-              </p>
-              
-              {process.env.NODE_ENV === 'development' && this.state.error && (
-                <details className="mt-4">
-                  <summary className="cursor-pointer text-sm font-medium text-muted-foreground hover:text-foreground">
-                    Detalhes do erro (desenvolvimento)
-                  </summary>
-                  <div className="mt-2 p-3 bg-muted rounded-lg">
-                    <pre className="text-xs overflow-auto max-h-32">
-                      {this.state.error.message}
-                      {this.state.error.stack}
-                    </pre>
-                  </div>
-                </details>
-              )}
-              
-              <div className="flex gap-2 pt-4">
-                <Button 
-                  onClick={this.handleReset}
-                  variant="outline" 
-                  className="flex-1"
-                >
-                  <RefreshCw className="w-4 h-4 mr-2" />
-                  Tentar Novamente
-                </Button>
-                <Button 
-                  onClick={this.handleGoHome}
-                  variant="default"
-                  className="flex-1"
-                >
-                  <Home className="w-4 h-4 mr-2" />
-                  Ir para Início
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-      );
+      return <ServerError onRetry={this.handleReset} />;
     }
 
     return this.props.children;

--- a/src/pages/ServerError.tsx
+++ b/src/pages/ServerError.tsx
@@ -1,20 +1,15 @@
-import { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Activity, Home, LifeBuoy, Search } from "lucide-react";
+import { Activity, AlertTriangle, Home, LifeBuoy, RefreshCw, Search } from "lucide-react";
 
-const NotFound = () => {
-  const location = useLocation();
+interface ServerErrorProps {
+  onRetry?: () => void;
+}
+
+const ServerError = ({ onRetry }: ServerErrorProps) => {
   const [query, setQuery] = useState("");
-
-  useEffect(() => {
-    console.error(
-      "404 Error: User attempted to access non-existent route:",
-      location.pathname
-    );
-  }, [location.pathname]);
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
@@ -23,15 +18,26 @@ const NotFound = () => {
     }
   };
 
+  const handleRetry = () => {
+    if (onRetry) {
+      onRetry();
+    } else {
+      window.location.reload();
+    }
+  };
+
   return (
     <div className="min-h-screen flex items-center justify-center p-4 bg-gradient-subtle">
       <Card className="w-full max-w-lg">
         <CardHeader className="text-center">
-          <CardTitle>Página não encontrada</CardTitle>
+          <div className="mx-auto w-12 h-12 bg-destructive/10 rounded-full flex items-center justify-center mb-4">
+            <AlertTriangle className="w-6 h-6 text-destructive" />
+          </div>
+          <CardTitle>Erro interno do servidor</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           <p className="text-center text-muted-foreground">
-            A página que você procura não existe. Tente buscar novamente ou acessar uma das opções abaixo.
+            Ocorreu um problema inesperado. Você pode tentar novamente ou usar os links abaixo.
           </p>
           <form
             onSubmit={handleSearch}
@@ -39,11 +45,11 @@ const NotFound = () => {
             aria-label="Buscar conteúdo"
             className="flex gap-2"
           >
-            <label htmlFor="search" className="sr-only">
+            <label htmlFor="error-search" className="sr-only">
               Buscar
             </label>
             <Input
-              id="search"
+              id="error-search"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Buscar..."
@@ -55,6 +61,9 @@ const NotFound = () => {
             </Button>
           </form>
           <div className="grid grid-cols-2 gap-2 pt-2">
+            <Button onClick={handleRetry} className="w-full" aria-label="Tentar novamente">
+              <RefreshCw className="w-4 h-4 mr-2" /> Tentar novamente
+            </Button>
             <Button asChild variant="secondary" className="w-full">
               <a href="/" aria-label="Ir para o início">
                 <Home className="w-4 h-4 mr-2" /> Início
@@ -90,4 +99,4 @@ const NotFound = () => {
   );
 };
 
-export default NotFound;
+export default ServerError;

--- a/src/tests/errorPages.test.tsx
+++ b/src/tests/errorPages.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import NotFound from '@/pages/NotFound';
+import ServerError from '@/pages/ServerError';
+
+describe('Error pages', () => {
+  it('NotFound provides navigation and search', () => {
+    render(<NotFound />);
+    expect(
+      screen.getByRole('heading', { name: /página não encontrada/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /buscar/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /início/i })).toHaveAttribute('href', '/');
+    expect(screen.getByRole('link', { name: /suporte/i })).toHaveAttribute(
+      'href',
+      'mailto:suporte@assistjur.com'
+    );
+    expect(screen.getByRole('link', { name: /status/i })).toHaveAttribute(
+      'href',
+      'https://status.assistjur.com'
+    );
+  });
+
+  it('ServerError calls retry handler', () => {
+    const onRetry = vi.fn();
+    render(<ServerError onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole('button', { name: /tentar novamente/i }));
+    expect(onRetry).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add themed 404 page with search and helpful links
- introduce server error page with retry option
- reuse server error page in error boundary and expose /500 route

## Testing
- ⚠️ `npm test` *(vitest not found)*
- ⚠️ `npm run lint` *(missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68c209c99258832296ce8f801db4bb4b