### PR TITLE
feat: serve static privacy and terms

### DIFF
--- a/scripts/prerender.tsx
+++ b/scripts/prerender.tsx
@@ -4,14 +4,19 @@ import React from 'react';
 import { renderToString, renderToStaticMarkup } from 'react-dom/server';
 import { StaticRouter } from 'react-router-dom/server';
 import PublicHome from '../src/pages/PublicHome';
-import TermsOfUse from '../src/pages/TermsOfUse';
-import PrivacyPolicy from '../src/pages/PrivacyPolicy';
 import { Head } from '../src/lib/head';
+
+const staticPagesDir = path.resolve(__dirname, '..', 'src', 'pages-static');
 
 const routes = [
   {
     path: '/',
-    component: PublicHome,
+    render: () =>
+      renderToString(
+        <StaticRouter location="/">
+          <PublicHome />
+        </StaticRouter>
+      ),
     head: {
       title: 'AssistJur.IA - Assistente de Testemunhas',
       description:
@@ -21,7 +26,7 @@ const routes = [
   },
   {
     path: '/termos',
-    component: TermsOfUse,
+    render: () => fs.readFileSync(path.join(staticPagesDir, 'termos.html'), 'utf-8'),
     head: {
       title: 'Termos de Uso - AssistJur.IA',
       description:
@@ -31,7 +36,7 @@ const routes = [
   },
   {
     path: '/privacidade',
-    component: PrivacyPolicy,
+    render: () => fs.readFileSync(path.join(staticPagesDir, 'privacidade.html'), 'utf-8'),
     head: {
       title: 'Política de Privacidade - AssistJur.IA',
       description:
@@ -45,12 +50,7 @@ const distDir = path.resolve(__dirname, '..', 'dist');
 const template = fs.readFileSync(path.join(distDir, 'index.html'), 'utf-8');
 
 for (const route of routes) {
-  const appHtml = renderToString(
-    <StaticRouter location={route.path}>
-      <route.component />
-    </StaticRouter>
-  );
-
+  const appHtml = route.render();
   const headHtml = renderToStaticMarkup(<Head {...route.head} path={route.path} />);
 
   let html = template.replace('<div id="root"></div>', `<div id="root">${appHtml}</div>`);

--- a/src/components/common/FooterLegal.tsx
+++ b/src/components/common/FooterLegal.tsx
@@ -26,10 +26,10 @@ export function FooterLegal() {
           <button onClick={() => setOpen(true)} className={linkClasses}>
             Privacidade / Gerenciar cookies
           </button>
-          <Link to="/politica-de-privacidade" className={linkClasses}>
+          <Link to="/privacidade" className={linkClasses}>
             Política de Privacidade
           </Link>
-          <Link to="/termos-de-uso" className={linkClasses}>
+          <Link to="/termos" className={linkClasses}>
             Termos de Uso
           </Link>
           <Link to="/lgpd" className={linkClasses}>

--- a/src/pages-static/privacidade.html
+++ b/src/pages-static/privacidade.html
@@ -1,0 +1,4 @@
+<main class="container mx-auto px-6 py-8">
+  <h1 class="text-2xl font-bold mb-4">Política de Privacidade</h1>
+  <p>Esta é a página de política de privacidade.</p>
+</main>

--- a/src/pages-static/termos.html
+++ b/src/pages-static/termos.html
@@ -1,0 +1,4 @@
+<main class="container mx-auto px-6 py-8">
+  <h1 class="text-2xl font-bold mb-4">Termos de Uso</h1>
+  <p>Esta é a página de termos de uso.</p>
+</main>

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
+import privacyHtml from '@/pages-static/privacidade.html?raw';
 
 export default function PrivacyPolicy() {
-  return (
-    <main className="container mx-auto px-6 py-8">
-      <h1 className="text-2xl font-bold mb-4">Política de Privacidade</h1>
-      <p>Esta é a página de política de privacidade.</p>
-    </main>
-  );
+  return <div dangerouslySetInnerHTML={{ __html: privacyHtml }} />;
 }

--- a/src/pages/TermsOfUse.tsx
+++ b/src/pages/TermsOfUse.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
+import termosHtml from '@/pages-static/termos.html?raw';
 
 export default function TermsOfUse() {
-  return (
-    <main className="container mx-auto px-6 py-8">
-      <h1 className="text-2xl font-bold mb-4">Termos de Uso</h1>
-      <p>Esta é a página de termos de uso.</p>
-    </main>
-  );
+  return <div dangerouslySetInnerHTML={{ __html: termosHtml }} />;
 }


### PR DESCRIPTION
## Summary
- add static HTML templates for privacy policy and terms of use
- prerender terms/privacy pages from static files
- update footer to link to new static routes

## Testing
- `npm test -- --run` (fails: Test Files 0 passed (272) ... queued node_modules tests)


------
https://chatgpt.com/codex/tasks/task_e_68c48ccee5688322a3cb77342f554628