### PR TITLE
feat: optimize landing bundle via lazy chunks

### DIFF
--- a/src/components/home/FeatureCard.tsx
+++ b/src/components/home/FeatureCard.tsx
@@ -1,7 +1,8 @@
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { LucideIcon, ArrowRight, ExternalLink } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { ArrowRight, ExternalLink } from "lucide-react";
 
 interface FeatureCardProps {
   icon: LucideIcon;

--- a/src/components/templates/ReportSection.tsx
+++ b/src/components/templates/ReportSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { LucideIcon } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface ReportSectionProps {

--- a/src/config/sidebar.ts
+++ b/src/config/sidebar.ts
@@ -1,18 +1,18 @@
-import { 
-  Home, 
-  Users, 
-  MessageSquare, 
-  BarChart3, 
-  LineChart, 
-  Database, 
-  Upload, 
-  History, 
-  Briefcase, 
-  ShieldCheck, 
-  ClipboardList, 
-  Settings,
-  LucideIcon
+import {
+  Home,
+  Users,
+  MessageSquare,
+  BarChart3,
+  LineChart,
+  Database,
+  Upload,
+  History,
+  Briefcase,
+  ShieldCheck,
+  ClipboardList,
+  Settings
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 
 export type NavItem = {
   label: string;

--- a/src/pages/PublicHome.tsx
+++ b/src/pages/PublicHome.tsx
@@ -1,18 +1,36 @@
-import React, { useState } from 'react';
+import React, { useState, lazy, Suspense } from 'react';
 import { PublicHeader } from '@/components/site/PublicHeader';
 import { ImprovedHero } from '@/components/site/ImprovedHero';
-import { ValueProps } from '@/components/site/ValueProps';
-import { Audience } from '@/components/site/Audience';
-import { AgentsPreview } from '@/components/site/AgentsPreview';
-import { ROI } from '@/components/site/ROI';
-import { SecurityAccordion } from '@/components/site/SecurityAccordion';
-import { AboutAssistJur } from '@/components/site/AboutAssistJur';
-import { AboutBianca } from '@/components/site/AboutBianca';
 import { Footer } from '@/components/site/Footer';
 import { BetaModal } from '@/components/sobre/BetaModal';
 import { Toaster } from '@/components/ui/toaster';
 import { BackToTopFAB } from '@/components/site/BackToTopFAB';
 import { SEO } from '@/seo/SEO';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const ValueProps = lazy(() =>
+  import('@/components/site/ValueProps').then((m) => ({ default: m.ValueProps }))
+);
+const Audience = lazy(() =>
+  import('@/components/site/Audience').then((m) => ({ default: m.Audience }))
+);
+const AgentsPreview = lazy(() =>
+  import('@/components/site/AgentsPreview').then((m) => ({ default: m.AgentsPreview }))
+);
+const ROI = lazy(() =>
+  import('@/components/site/ROI').then((m) => ({ default: m.ROI }))
+);
+const SecurityAccordion = lazy(() =>
+  import('@/components/site/SecurityAccordion').then((m) => ({ default: m.SecurityAccordion }))
+);
+const AboutAssistJur = lazy(() =>
+  import('@/components/site/AboutAssistJur').then((m) => ({ default: m.AboutAssistJur }))
+);
+const AboutBianca = lazy(() =>
+  import('@/components/site/AboutBianca').then((m) => ({ default: m.AboutBianca }))
+);
+
+const SectionSkeleton = () => <Skeleton className="h-64 w-full" />;
 
 export default function PublicHome() {
   const [isBetaModalOpen, setIsBetaModalOpen] = useState(false);
@@ -42,40 +60,56 @@ export default function PublicHome() {
         <ImprovedHero onSignup={handleBetaSignup} />
 
         {/* 2. Diferencial AssistJur.IA */}
-        <ValueProps />
+        <Suspense fallback={<SectionSkeleton />}>
+          <ValueProps />
+        </Suspense>
 
         {/* 3. Para Quem */}
         <section id="publico">
-          <Audience />
+          <Suspense fallback={<SectionSkeleton />}>
+            <Audience />
+          </Suspense>
         </section>
 
         {/* 4. Preview dos Agentes */}
         <section id="agentes">
-          <AgentsPreview />
+          <Suspense fallback={<SectionSkeleton />}>
+            <AgentsPreview />
+          </Suspense>
         </section>
 
         {/* 5. ROI */}
         <section id="roi">
-          <ROI onSignup={handleBetaSignup} />
+          <Suspense fallback={<SectionSkeleton />}>
+            <ROI onSignup={handleBetaSignup} />
+          </Suspense>
         </section>
 
         {/* 6. Segurança & Conformidade */}
         <section id="seguranca">
-          <SecurityAccordion />
+          <Suspense fallback={<SectionSkeleton />}>
+            <SecurityAccordion />
+          </Suspense>
         </section>
 
         {/* 7. Sobre o AssistJur.IA */}
         <section id="sobre">
-          <AboutAssistJur />
+          <Suspense fallback={<SectionSkeleton />}>
+            <AboutAssistJur />
+          </Suspense>
         </section>
 
         {/* 8. Sobre Bianca Reinstein */}
         <section id="bianca">
-          <AboutBianca />
+          <Suspense fallback={<SectionSkeleton />}>
+            <AboutBianca />
+          </Suspense>
         </section>
 
         {/* 9. Footer */}
-        <Footer />
+        <Suspense fallback={<SectionSkeleton />}>
+          <Footer />
+        </Suspense>
       </main>
 
       {/* Beta Modal */}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,5 +58,22 @@ export default defineConfig(async ({ mode }) => {
       port: 8080,
     },
     plugins: plugins.filter(Boolean),
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('node_modules')) {
+              if (id.includes('react') || id.includes('lucide-react')) {
+                return 'vendor';
+              }
+            }
+            if (id.includes('/src/pages/')) {
+              const name = id.split('/src/pages/')[1].split('/')[0].split('.')[0];
+              return `page-${name}`;
+            }
+          },
+        },
+      },
+    },
   };
 });


### PR DESCRIPTION
## Summary
- split landing page sections into lazy chunks with light skeleton fallbacks
- vendor and route chunking configured through Vite manualChunks
- tree-shake lucide icons with type-only imports

## Testing
- `npm test` *(fails: Cannot find module '/workspace/assitjur/src/tests/setup.ts')*
- `npm run lint` *(fails: 602 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c559c8213c83228b9a2ac29c2d12e7