### PR TITLE
chore: update sitemap and robots

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,3 @@
 User-agent: *
-Disallow:
-
+Allow: /
 Sitemap: https://assistjur.com.br/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,30 +2,30 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://assistjur.com.br/</loc>
-    <lastmod>2025-09-11T20:53:06.948Z</lastmod>
-  </url>
-  <url>
-    <loc>https://assistjur.com.br/mapa</loc>
-    <lastmod>2025-09-11T20:53:06.948Z</lastmod>
-  </url>
-  <url>
-    <loc>https://assistjur.com.br/planos</loc>
-    <lastmod>2025-09-11T20:53:06.948Z</lastmod>
-  </url>
-  <url>
-    <loc>https://assistjur.com.br/contato</loc>
-    <lastmod>2025-09-11T20:53:06.948Z</lastmod>
+    <lastmod>2025-09-13T13:43:43.065Z</lastmod>
   </url>
   <url>
     <loc>https://assistjur.com.br/blog</loc>
-    <lastmod>2025-09-11T20:53:06.948Z</lastmod>
+    <lastmod>2025-09-13T13:43:43.065Z</lastmod>
   </url>
   <url>
-    <loc>https://assistjur.com.br/termos</loc>
-    <lastmod>2025-09-11T20:53:06.948Z</lastmod>
+    <loc>https://assistjur.com.br/contato</loc>
+    <lastmod>2025-09-13T13:43:43.065Z</lastmod>
+  </url>
+  <url>
+    <loc>https://assistjur.com.br/mapa</loc>
+    <lastmod>2025-09-13T13:43:43.065Z</lastmod>
+  </url>
+  <url>
+    <loc>https://assistjur.com.br/planos</loc>
+    <lastmod>2025-09-13T13:43:43.065Z</lastmod>
   </url>
   <url>
     <loc>https://assistjur.com.br/privacidade</loc>
-    <lastmod>2025-09-11T20:53:06.948Z</lastmod>
+    <lastmod>2025-09-13T13:43:43.065Z</lastmod>
+  </url>
+  <url>
+    <loc>https://assistjur.com.br/termos</loc>
+    <lastmod>2025-09-13T13:43:43.065Z</lastmod>
   </url>
 </urlset>

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,5 +1,6 @@
 import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
+import { fileURLToPath } from 'url';
 
 const BASE_URL = process.env.VITE_PUBLIC_SITE_URL || process.env.SITE_URL || 'https://assistjur.com.br';
 const routesPath = new URL('./routes.json', import.meta.url);
@@ -12,7 +13,7 @@ const stripTracking = (url) =>
 
 async function generate() {
   const raw = await readFile(routesPath, 'utf8');
-  const routes = [...new Set(JSON.parse(raw))];
+  const routes = [...new Set(JSON.parse(raw))].sort();
   const lastmod = new Date().toISOString();
 
   const urls = routes
@@ -26,7 +27,8 @@ async function generate() {
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
 
-  const outPath = join(new URL('.', import.meta.url).pathname, '../public/sitemap.xml');
+  const outDir = fileURLToPath(new URL('../public', import.meta.url));
+  const outPath = join(outDir, 'sitemap.xml');
   await writeFile(outPath, xml, 'utf8');
   console.log(`sitemap.xml generated with ${routes.length} routes`);
 }


### PR DESCRIPTION
## Summary
- ensure sitemap generation is cross-platform and sorted
- update robots.txt to allow all paths and reference sitemap

## Testing
- `node scripts/generate-sitemap.mjs`
- `npm test -- --run` *(fails: Cannot find module '/workspace/assitjur/src/tests/setup.ts')*
- `npx lint-staged` *(fails: Invalid value for 'linters' in lint-staged config)*

------
https://chatgpt.com/codex/tasks/task_e_68c574b605f48322bfea58c90c97ede1