### PR TITLE
feat: add consent-aware tracking for beta CTAs

### DIFF
--- a/src/components/beta/BetaSignup.tsx
+++ b/src/components/beta/BetaSignup.tsx
@@ -12,6 +12,7 @@ import { EmailHint } from './EmailHint';
 import { Fieldset } from './Fieldset';
 import { supabase } from '@/integrations/supabase/client';
 import { disposableDomains } from '@/config/disposableDomains';
+import { track } from '@/lib/track';
 
 const emailRegex = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
 
@@ -195,7 +196,7 @@ export function BetaSignup({ compact = false, className = '', variant = 'inline'
     
     try {
       // Track form submission
-      console.log('beta_form_submitted', data);
+      track('beta_submit', { email_domain: data.email.split('@')[1] });
       
       // Get UTM parameters
       const urlParams = new URLSearchParams(window.location.search);

--- a/src/components/site/Hero.tsx
+++ b/src/components/site/Hero.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { ArrowDown } from 'lucide-react';
 import { NeedsForm } from './NeedsForm';
 import { BrandLogo } from '@/components/brand/BrandLogo';
+import { track } from '@/lib/track';
 
 interface HeroProps {
   onSignup?: (data: { email: string; needs: string[]; otherNeed?: string }) => void;
@@ -12,6 +13,7 @@ export function Hero({ onSignup }: HeroProps) {
   const [showForm, setShowForm] = useState(false);
 
   const scrollToForm = () => {
+    track('cta_click', { id: 'hero-testar-hub' });
     setShowForm(true);
     setTimeout(() => {
       const formElement = document.getElementById('needs-form');

--- a/src/components/site/ImprovedHero.tsx
+++ b/src/components/site/ImprovedHero.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { ArrowDown, Sparkles } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { NeedsForm } from './NeedsForm';
+import { track } from '@/lib/track';
 
 interface ImprovedHeroProps {
   onSignup?: (data: { email: string; needs: string[]; otherNeed?: string }) => void;
@@ -15,6 +16,7 @@ export function ImprovedHero({ onSignup }: ImprovedHeroProps) {
   const navigate = useNavigate();
 
   const scrollToForm = () => {
+    track('cta_click', { id: 'hero-testar-hub' });
     setFormVisible(true);
     setTimeout(() => {
       const formElement = document.getElementById('needs-form');

--- a/src/components/site/NeedsForm.tsx
+++ b/src/components/site/NeedsForm.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Textarea } from '@/components/ui/textarea';
 import { useBetaFormStore } from '@/stores/useBetaFormStore';
 import { Loader2, ArrowRight } from 'lucide-react';
+import { track } from '@/lib/track';
 
 interface NeedsFormProps {
   onSubmit?: (data: { email: string; needs: string[]; otherNeed?: string }) => void;
@@ -186,9 +187,10 @@ export function NeedsForm({ onSubmit }: NeedsFormProps) {
           </div>
 
           {/* Submit */}
-          <Button 
-            type="submit" 
+          <Button
+            type="submit"
             disabled={loading || !email || (needs.length === 0 && !otherNeed)}
+            onClick={() => track('cta_click', { id: 'mid-entrar-beta' })}
             className="w-full bg-gradient-primary hover:bg-primary/90 hover:shadow-glow text-lg py-6 transition-all duration-300 group"
           >
             {loading ? (

--- a/src/components/site/PublicHeader.tsx
+++ b/src/components/site/PublicHeader.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { track } from '@/lib/track';
 
 interface PublicHeaderProps {
   onBetaClick?: () => void;
@@ -66,6 +67,7 @@ export function PublicHeader({ onBetaClick }: PublicHeaderProps) {
               onClick={(e) => {
                 if (onBetaClick) {
                   e.preventDefault();
+                  track('cta_click', { id: 'menu-entrar-beta' });
                   onBetaClick();
                 }
               }}
@@ -143,6 +145,7 @@ export function PublicHeader({ onBetaClick }: PublicHeaderProps) {
                   onClick={(e) => {
                     if (onBetaClick) {
                       e.preventDefault();
+                      track('cta_click', { id: 'menu-entrar-beta' });
                       onBetaClick();
                     }
                   }}

--- a/src/lib/track.ts
+++ b/src/lib/track.ts
@@ -1,0 +1,20 @@
+import { getConsent } from '@/lib/consent'
+
+export function track(eventName: string, payload?: Record<string, any>) {
+  try {
+    if (getConsent().measure !== true) return
+
+    fetch('/api/track', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        event: eventName,
+        payload,
+        timestamp: new Date().toISOString(),
+      }),
+      keepalive: true,
+    }).catch(() => {})
+  } catch {
+    // ignore errors
+  }
+}

--- a/src/stores/useBetaFormStore.ts
+++ b/src/stores/useBetaFormStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { toast } from '@/hooks/use-toast';
+import { track } from '@/lib/track';
 
 interface BetaFormState {
   email: string;
@@ -44,8 +45,10 @@ export const useBetaFormStore = create<BetaFormStore>((set, get) => ({
 
   submitBeta: async () => {
     const { email, needs, otherNeed } = get();
-    
+
     set({ loading: true, error: null });
+
+    track('beta_submit', { email_domain: email.split('@')[1] });
 
     try {
       // Preparar payload


### PR DESCRIPTION
## Summary
- add lightweight track utility gated by measurement consent
- track CTA clicks in hero, header menu, and mid-page beta form
- record beta signups with email domain

## Testing
- `npm test` *(fails: Cannot find module 'src/tests/setup.ts')*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c576d046308322a4ce1b16e10af1fc