### PR TITLE
Add website honeypot to beta signup forms

### DIFF
--- a/src/components/beta/BetaSignup.tsx
+++ b/src/components/beta/BetaSignup.tsx
@@ -29,7 +29,7 @@ const betaSignupSchema = z.object({
   organizacao: z.string().min(2, 'Organização deve ter pelo menos 2 caracteres'),
   necessidades: z.array(z.string()).min(1, 'Selecione pelo menos uma necessidade'),
   outro_texto: z.string().max(120, 'Máximo 120 caracteres').optional(),
-  honeypot: z.string().max(0).optional(),
+  website: z.string().max(0).optional(),
   consentimento: z.boolean().refine(val => val === true, {
     message: 'É necessário seu consentimento',
   }),
@@ -117,7 +117,7 @@ export function BetaSignup({ compact = false, className = '', variant = 'inline'
     defaultValues: {
       consentimento: false,
       termos: false,
-      honeypot: '',
+      website: '',
     },
   });
 
@@ -187,6 +187,9 @@ export function BetaSignup({ compact = false, className = '', variant = 'inline'
   };
 
   const onSubmit = async (data: BetaSignupForm) => {
+    if (data.website) {
+      return;
+    }
     const now = Date.now();
     if (now - lastSubmitRef.current < 1000) {
       return;
@@ -282,14 +285,15 @@ export function BetaSignup({ compact = false, className = '', variant = 'inline'
 
       {/* Form */}
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-        <div className="hidden" aria-hidden="true">
-          <input
-            type="text"
-            tabIndex={-1}
-            autoComplete="off"
-            {...register('honeypot')}
-          />
-        </div>
+        <input
+          type="text"
+          name="website"
+          className="hidden"
+          tabIndex={-1}
+          autoComplete="off"
+          aria-hidden="true"
+          {...register('website')}
+        />
         {/* Nome */}
         <Fieldset
           label="Nome completo"

--- a/src/components/site/NeedsForm.tsx
+++ b/src/components/site/NeedsForm.tsx
@@ -44,9 +44,12 @@ export function NeedsForm({ onSubmit }: NeedsFormProps) {
     }
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    
+
+    const formData = new FormData(e.currentTarget);
+    if (formData.get('website')) return;
+
     // Validations
     const newErrors: { email?: string; needs?: string } = {};
     
@@ -91,6 +94,14 @@ export function NeedsForm({ onSubmit }: NeedsFormProps) {
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-6">
+          <input
+            type="text"
+            name="website"
+            className="hidden"
+            tabIndex={-1}
+            autoComplete="off"
+            aria-hidden="true"
+          />
           {/* Necessidades */}
           <div className="space-y-4">
             <div className="grid grid-cols-1 gap-4">

--- a/src/components/sobre/BetaModal.tsx
+++ b/src/components/sobre/BetaModal.tsx
@@ -20,9 +20,12 @@ export function BetaModal({ isOpen = false, onClose }: BetaModalProps) {
   const [email, setEmail] = useState('');
   const { loading, submitBeta } = useBetaFormStore();
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    
+
+    const formData = new FormData(e.currentTarget);
+    if (formData.get('website')) return;
+
     if (!email) return;
 
     // Temporarily set the email in the store for submission
@@ -49,6 +52,14 @@ export function BetaModal({ isOpen = false, onClose }: BetaModalProps) {
         </DialogHeader>
         
         <form onSubmit={handleSubmit} className="space-y-6">
+          <input
+            type="text"
+            name="website"
+            className="hidden"
+            tabIndex={-1}
+            autoComplete="off"
+            aria-hidden="true"
+          />
           <div className="space-y-4">
             <div>
               <Label htmlFor="email" className="text-sm font-medium">


### PR DESCRIPTION
## Summary
- Add hidden `website` honeypot field to beta signup components
- Abort submission when honeypot is filled to reduce spam

## Testing
- `npx vitest run tests/beta-signup-validation.test.tsx` *(fails: Cannot find module '/workspace/assitjur/src/tests/setup.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68c5797b6fac832297a006afe598bdb0