### PR TITLE
feat(pwa): add service worker caching with 404 fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,9 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
     "vite": "^5.4.19",
+    "vite-plugin-pwa": "^0.20.0",
     "vite-tsconfig-paths": "^5.1.4",
+    "workbox-precaching": "^7.0.0",
     "yargs": "^17.7.2"
   },
   "engines": {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -59,3 +59,11 @@ createRoot(document.getElementById('root')!).render(
     </MaintenanceProvider>
   </StrictMode>
 )
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('/sw.js')
+      .catch((err) => console.error('SW registration failed', err))
+  })
+}

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,0 +1,42 @@
+/// <reference lib="webworker" />
+declare const self: ServiceWorkerGlobalScope
+
+import { precacheAndRoute, cleanupOutdatedCaches } from 'workbox-precaching'
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting()
+  }
+})
+
+cleanupOutdatedCaches()
+// @ts-ignore __WB_MANIFEST is injected by workbox at build time
+precacheAndRoute(self.__WB_MANIFEST)
+
+const AUTH_PATHS = ['/mapa', '/mapa-testemunhas', '/dados', '/admin', '/relatorio', '/account', '/import']
+
+self.addEventListener('fetch', (event: FetchEvent) => {
+  const { request } = event
+
+  if (request.method !== 'GET') return
+
+  const accept = request.headers.get('accept') || ''
+  if (accept.includes('application/json') || request.headers.get('x-requested-with') === 'XMLHttpRequest') {
+    return
+  }
+
+  const url = new URL(request.url)
+  if (AUTH_PATHS.some((p) => url.pathname.startsWith(p))) {
+    return
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request).catch(() => caches.match('/404.html'))
+    )
+  }
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim())
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import { componentTagger } from "lovable-tagger";
 import { brotliCompress, gzip } from "node:zlib";
 import { promisify } from "node:util";
+import { VitePWA } from 'vite-plugin-pwa'
 
 const gzipAsync = promisify(gzip);
 const brotliAsync = promisify(brotliCompress);
@@ -45,6 +46,26 @@ export default defineConfig(async ({ mode }) => {
     tsconfigPaths(),
     mode === 'development' && componentTagger(),
     mode !== 'development' && compressPlugin(),
+    VitePWA({
+      srcDir: 'src',
+      filename: 'sw.ts',
+      strategies: 'injectManifest',
+      registerType: 'autoUpdate',
+      includeAssets: ['favicon.ico', 'robots.txt', '404.html'],
+      manifest: {
+        name: 'Assistjur',
+        short_name: 'Assistjur',
+        start_url: '/',
+        display: 'standalone',
+        icons: [
+          {
+            src: '/favicon.svg',
+            sizes: 'any',
+            type: 'image/svg+xml',
+          },
+        ],
+      },
+    }),
   ];
 
   if (process.env.ANALYZE) {
@@ -61,7 +82,7 @@ export default defineConfig(async ({ mode }) => {
     build: {
       rollupOptions: {
         output: {
-          manualChunks(id) {
+          manualChunks(id: string) {
             if (id.includes('node_modules')) {
               if (id.includes('react') || id.includes('lucide-react')) {
                 return 'vendor';


### PR DESCRIPTION
## Summary
- register service worker for hashed asset caching and offline 404 fallback
- integrate vite-plugin-pwa injectManifest build setup
- add service worker registration in app entry

## Testing
- `npm test` *(fails: Cannot find module '/workspace/assitjur/src/tests/setup.ts')*
- `npm run build` *(fails: Cannot find module 'workbox-precaching')*


------
https://chatgpt.com/codex/tasks/task_e_68c57f24f8f08322a5d095fc7be29e97