### PR TITLE
Use accessible link for beta header logo

### DIFF
--- a/src/components/beta/BetaHeader.tsx
+++ b/src/components/beta/BetaHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { BrandLogo } from '@/components/brand/BrandLogo';
 
 export function BetaHeader() {
@@ -12,9 +12,13 @@ export function BetaHeader() {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
-          <div className="flex items-center space-x-3 cursor-pointer transition-transform duration-200 hover:scale-105" onClick={() => navigate('/')}>
+          <Link
+            to="/"
+            aria-label="Página inicial"
+            className="flex items-center space-x-3 cursor-pointer transition-transform duration-200 hover:scale-105"
+          >
             <BrandLogo size="lg" className="h-10 md:h-12" />
-          </div>
+          </Link>
 
           {/* Navigation */}
           <div className="flex items-center space-x-4">

--- a/tests/beta-header-keyboard.test.tsx
+++ b/tests/beta-header-keyboard.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BrowserRouter } from 'react-router-dom';
+
+import { BetaHeader } from '@/components/beta/BetaHeader';
+
+describe('BetaHeader logo link', () => {
+  it('is focusable and navigates home on click', () => {
+    window.history.pushState({}, '', '/beta');
+    render(
+      <BrowserRouter>
+        <BetaHeader />
+      </BrowserRouter>
+    );
+
+    const link = screen.getByRole('link', { name: 'Página inicial' });
+    link.focus();
+    expect(link).toHaveFocus();
+
+    fireEvent.click(link);
+    expect(window.location.pathname).toBe('/');
+  });
+});


### PR DESCRIPTION
## Summary
- replace clickable div with `Link` in beta header logo
- add aria-label for screen readers
- add test verifying focus and navigation

## Testing
- `npm test` *(fails: Cannot find module '/workspace/assitjur/src/tests/setup.ts')*
- `npx vitest run --config vitest.temp.config.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c6a18b5ba883228baa3b38f7c43ea9