### PR TITLE
fix: improve login hover contrast

### DIFF
--- a/src/components/site/PublicHeader.tsx
+++ b/src/components/site/PublicHeader.tsx
@@ -58,7 +58,7 @@ export function PublicHeader({ onBetaClick }: PublicHeaderProps) {
           <div className="hidden md:flex items-center gap-3">
             <a
               href="/login"
-              className="px-4 py-2 rounded-md border border-purple-500 text-purple-300 hover:bg-purple-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-purple-400 focus:ring-offset-2 focus:ring-offset-[#1e0033]"
+              className="px-4 py-2 rounded-md border border-purple-500 text-purple-300 hover:bg-purple-600 hover:text-gray-50 focus:outline-none focus:ring-2 focus:ring-purple-400 focus:ring-offset-2 focus:ring-offset-[#1e0033]"
             >
               Login
             </a>
@@ -136,7 +136,7 @@ export function PublicHeader({ onBetaClick }: PublicHeaderProps) {
               <li className="pt-2 flex flex-col gap-3">
                 <a
                   href="/login"
-                  className="px-4 py-2 rounded-md border border-purple-500 text-purple-300 hover:bg-purple-500 hover:text-white text-center focus:outline-none focus:ring-2 focus:ring-purple-400 focus:ring-offset-2 focus:ring-offset-[#1e0033]"
+                  className="px-4 py-2 rounded-md border border-purple-500 text-purple-300 hover:bg-purple-600 hover:text-gray-50 text-center focus:outline-none focus:ring-2 focus:ring-purple-400 focus:ring-offset-2 focus:ring-offset-[#1e0033]"
                 >
                   Login
                 </a>


### PR DESCRIPTION
## Summary
- adjust login link hover to purple-600 with gray-50 text for better contrast

## Testing
- `node -e "const hexToRgb=h=>[parseInt(h.slice(1,3),16),parseInt(h.slice(3,5),16),parseInt(h.slice(5,7),16)];const rel=([r,g,b])=>{const sr=r/255,sg=g/255,sb=b/255;const rLin=sr<=0.03928?sr/12.92:Math.pow((sr+0.055)/1.055,2.4);const gLin=sg<=0.03928?sg/12.92:Math.pow((sg+0.055)/1.055,2.4);const bLin=sb<=0.03928?sb/12.92:Math.pow((sb+0.055)/1.055,2.4);return 0.2126*rLin+0.7152*gLin+0.0722*bLin;};const contrast=(c1,c2)=>{const L1=rel(hexToRgb(c1));const L2=rel(hexToRgb(c2));const ratio=(Math.max(L1,L2)+0.05)/(Math.min(L1,L2)+0.05);return ratio;};console.log('contrast ratio:', contrast('#9333ea','#f9fafb').toFixed(2))"`
- `npm test` *(fails: Cannot find module '/workspace/assitjur/src/tests/setup.ts')*
- `npm run lint` *(fails: 603 problems (566 errors, 37 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68c6a18e74c883228e9a13224d4a5df1