### PR TITLE
test: add testing-library setup

### DIFF
--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,0 +1,32 @@
+import '@testing-library/jest-dom';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import { afterEach, expect, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { TextEncoder, TextDecoder } from 'util';
+
+// Extend Vitest's expect with jest-dom matchers
+expect.extend(matchers);
+
+// Polyfill window.matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }),
+});
+
+// Polyfill TextEncoder/TextDecoder for the testing environment
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder as any;
+
+// Clean up the DOM after each test to prevent test pollution
+afterEach(() => {
+  cleanup();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./src/tests/setup.ts'],
+    setupFiles: ['src/tests/setup.ts'],
     exclude: ['tests/integration.supabase.test.ts'],
     coverage: {
       reporter: ['lcov'],


### PR DESCRIPTION
## Summary
- add Jest DOM setup file with polyfills and cleanup
- reference setup file from Vitest config

## Testing
- `npx vitest run tests/demoMapaTestemunhas.test.tsx` *(fails: [AdminRoutes] is not a <Route> component)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a1a76a6c8322849ec07c71d26640