### PR TITLE
chore: expand vitest test globs

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,8 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/tests/setup.ts'],
-    exclude: ['tests/integration.supabase.test.ts'],
+    include: ['tests/**/*', 'src/**/*.test.{ts,tsx}'],
+    exclude: ['node_modules', 'dist', 'tests/integration.supabase.test.ts'],
     coverage: {
       reporter: ['lcov'],
     },


### PR DESCRIPTION
## Summary
- broaden vitest include globs for tests and src
- ignore node_modules and dist during unit testing

## Testing
- `npm test -- --run` *(fails: Cannot find module '/workspace/assitjur/src/tests/setup.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68c6a1aae94483229066f088b428e159