### PR TITLE
chore: enable v8 coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,11 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - run: npm run test
+      - run: npm run test:unit
+      - uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react-swc": "^4.0.1",
+    "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "^10.4.21",
     "axe-core": "^4.10.0",
     "chalk": "^5.3.0",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     setupFiles: ['./src/tests/setup.ts'],
     exclude: ['tests/integration.supabase.test.ts'],
     coverage: {
+      provider: 'v8',
       reporter: ['lcov'],
     },
   },


### PR DESCRIPTION
## Summary
- add v8 coverage plugin for vitest
- configure vitest to use V8 coverage provider
- publish coverage reports in CI via Codecov

## Testing
- `npm run test:unit` *(fails: Cannot find dependency '@vitest/coverage-v8')*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a1ac36ec8322a56f50e9351d1b26