### PR TITLE
test: mock analytics events

### DIFF
--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/tests/analytics-events.test.ts
+++ b/tests/analytics-events.test.ts
@@ -1,24 +1,51 @@
 /**
  * @vitest-environment node
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, afterAll, vi } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
-import { config as loadEnv } from 'dotenv';
 
-loadEnv({ path: '.env.local' });
+// Mock environment variables with static values
+vi.stubEnv('SUPABASE_TEST_URL', 'https://test.supabase.co');
+vi.stubEnv('SUPABASE_TEST_KEY', 'test-key');
 
-const url = process.env.SUPABASE_TEST_URL as string | undefined;
-const key = process.env.SUPABASE_TEST_KEY as string | undefined;
+// In-memory store for intercepted analytics events
+const events: any[] = [];
 
-const supabase = url && key ? createClient(url, key) : null;
+// Custom fetch to intercept Supabase requests
+const fetchMock = async (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = typeof input === 'string' ? input : input.toString();
+  if (url.includes('/rest/v1/analytics_events')) {
+    const body = JSON.parse(init?.body as string) as any[];
+    events.push(...body);
+    return new Response(JSON.stringify(body), { status: 201 });
+  }
+  if (url.includes('/rest/v1/rpc/analytics_events_summary')) {
+    const counts: Record<string, number> = {};
+    for (const e of events) {
+      counts[e.event] = (counts[e.event] ?? 0) + 1;
+    }
+    const summary = Object.entries(counts).map(([event, count]) => ({ event, count }));
+    return new Response(JSON.stringify(summary), { status: 200 });
+  }
+  return Response.error();
+};
+
+const supabase = createClient(
+  process.env.SUPABASE_TEST_URL!,
+  process.env.SUPABASE_TEST_KEY!,
+  { global: { fetch: fetchMock } }
+);
+
+afterEach(() => {
+  events.length = 0; // Cleanup events after each test run
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 describe('analytics_events', () => {
   it('stores and aggregates events', async () => {
-    if (!supabase) {
-      console.warn('Skipping analytics_events test due to missing Supabase env vars');
-      return;
-    }
-
     await supabase.from('analytics_events').insert([
       { event: 'beta_signup', metadata: { source: 'test' } },
       { event: 'created_first_map', metadata: { source: 'test' } },


### PR DESCRIPTION
## Summary
- mock Supabase env vars for tests
- intercept analytics event requests with custom fetch and in-memory store
- clean up after each run and provide Vitest setup file

## Testing
- `npx vitest run tests/analytics-events.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c6a1c6bfc883228aea5ab1780f2d0b