### PR TITLE
test: add calculateRisk unit tests

### DIFF
--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,0 +1,2 @@
+import '@testing-library/jest-dom';
+export {};

--- a/tests/calculateRisk.test.ts
+++ b/tests/calculateRisk.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { calculateRisk, type SessionContext } from '@/security/sessionContext';
+
+describe('calculateRisk', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns minimum risk when no factors trigger', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T12:00:00Z'));
+    const ctx: SessionContext = {
+      userAgent: 'Mozilla/5.0',
+      timezone: 'UTC',
+      language: 'en-US',
+      platform: 'test',
+    };
+    const risk = calculateRisk('UTC', ctx);
+    expect(risk).toBe(0);
+    expect(risk).toBeGreaterThanOrEqual(0);
+  });
+
+  it('adds 40 points for timezone change', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T12:00:00Z'));
+    const ctx: SessionContext = {
+      userAgent: 'Mozilla/5.0',
+      timezone: 'Europe/London',
+      language: 'en-GB',
+      platform: 'test',
+    };
+    const risk = calculateRisk('America/New_York', ctx);
+    expect(risk).toBe(40);
+  });
+
+  it('adds 30 points for unusual login time', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T02:00:00Z'));
+    const ctx: SessionContext = {
+      userAgent: 'Mozilla/5.0',
+      timezone: 'UTC',
+      language: 'en-US',
+      platform: 'test',
+    };
+    const risk = calculateRisk('UTC', ctx);
+    expect(risk).toBe(30);
+  });
+
+  it('adds 30 points for suspicious user agent', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T12:00:00Z'));
+    const ctx: SessionContext = {
+      userAgent: 'HeadlessChrome',
+      timezone: 'UTC',
+      language: 'en-US',
+      platform: 'test',
+    };
+    const risk = calculateRisk('UTC', ctx);
+    expect(risk).toBe(30);
+  });
+
+  it('returns maximum risk when all factors trigger', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T23:00:00Z'));
+    const ctx: SessionContext = {
+      userAgent: 'test-bot',
+      timezone: 'Europe/London',
+      language: 'en-GB',
+      platform: 'test',
+    };
+    const risk = calculateRisk('America/New_York', ctx);
+    expect(risk).toBe(100);
+    expect(risk).toBeLessThanOrEqual(100);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add vitest setup placeholder
- cover risk scoring and bounds in calculateRisk

## Testing
- `npx vitest run tests/calculateRisk.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c6a1b9df9483229c50a1be29924285