### PR TITLE
feat: add AssistJur unified endpoints

### DIFF
--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,0 +1,13 @@
+import OpenAI from "openai";
+
+const apiKey = process.env.OPENAI_API_KEY || "";
+const organization = process.env.OPENAI_ORG;
+const project = process.env.OPENAI_PROJECT;
+
+export const openai = new OpenAI({
+  apiKey,
+  organization,
+  project,
+});
+
+export default openai;

--- a/src/lib/prompts/assistjurMaster.ts
+++ b/src/lib/prompts/assistjurMaster.ts
@@ -1,0 +1,1 @@
+export const assistjurMaster = `Você é o AssistJur, um assistente jurídico especializado em gerar orientações e modelos de documentos. Siga rigorosamente as instruções fornecidas e responda sempre em formato JSON.`;

--- a/src/lib/vectorStore.ts
+++ b/src/lib/vectorStore.ts
@@ -1,0 +1,19 @@
+import openai from "./openai";
+
+export async function getOrCreateVectorStore(name: string) {
+  const stores = await openai.beta.vectorStores.list({ limit: 100 });
+  const existing = stores.data.find(store => store.name === name);
+  if (existing) return existing;
+  return await openai.beta.vectorStores.create({ name });
+}
+
+export async function uploadFile(file: Blob | File) {
+  const uploaded = await openai.files.create({ file, purpose: "assistants" });
+  return uploaded.id;
+}
+
+export async function attachFile(fileId: string, vectorStoreId: string) {
+  await openai.beta.vectorStores.fileBatches.create(vectorStoreId, {
+    file_ids: [fileId],
+  });
+}

--- a/src/pages/api/assistjur/generate.ts
+++ b/src/pages/api/assistjur/generate.ts
@@ -1,0 +1,84 @@
+import openai from "@/lib/openai";
+import { getOrCreateVectorStore } from "@/lib/vectorStore";
+import { assistjurMaster } from "@/lib/prompts/assistjurMaster";
+import type { Mode, Citation } from "@/types/assistjur";
+
+interface GenerateRequest {
+  mode: Mode;
+  text?: string;
+  temaFase?: Record<string, unknown>;
+  entrevista?: Record<string, unknown>;
+  useRag?: boolean;
+  fileIds?: string[];
+}
+
+interface GenerateResponse {
+  promptPrincipal: string;
+  variacoes: {
+    compacta: string;
+    especialista: string;
+  };
+  perguntas?: string[];
+  checklist: string[];
+  citacoes?: Citation[];
+  avisoLegal: string;
+}
+
+export default async function handler(req: Request): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+
+  try {
+    const body = (await req.json()) as GenerateRequest;
+    if (!body.mode) {
+      return new Response("Missing mode", { status: 400 });
+    }
+
+    const messages = [
+      { role: "system", content: assistjurMaster },
+      {
+        role: "user",
+        content: JSON.stringify({
+          mode: body.mode,
+          text: body.text,
+          temaFase: body.temaFase,
+          entrevista: body.entrevista,
+        }),
+      },
+    ];
+
+    const options: Record<string, unknown> = {};
+    if (body.useRag) {
+      const store = await getOrCreateVectorStore("assistjur");
+      options.tools = [{ type: "file_search" }];
+      options.attachments = [{ vector_store_id: store.id }];
+    }
+
+    const response = await openai.responses.create({
+      model: "gpt-4.1-mini",
+      input: messages,
+      ...options,
+    });
+
+    let parsed: GenerateResponse;
+    try {
+      parsed = JSON.parse(response.output_text) as GenerateResponse;
+    } catch {
+      parsed = {
+        promptPrincipal: response.output_text,
+        variacoes: { compacta: "", especialista: "" },
+        checklist: [],
+        avisoLegal: "",
+      };
+    }
+
+    return new Response(JSON.stringify(parsed), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error(error);
+    return new Response("Internal Server Error", { status: 500 });
+  }
+}

--- a/src/pages/api/assistjur/upload.ts
+++ b/src/pages/api/assistjur/upload.ts
@@ -1,0 +1,27 @@
+import { getOrCreateVectorStore, uploadFile, attachFile } from "@/lib/vectorStore";
+
+export default async function handler(req: Request): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+
+  try {
+    const form = await req.formData();
+    const file = form.get("file");
+    if (!(file instanceof Blob)) {
+      return new Response("File is required", { status: 400 });
+    }
+
+    const store = await getOrCreateVectorStore("assistjur");
+    const fileId = await uploadFile(file);
+    await attachFile(fileId, store.id);
+
+    return new Response(JSON.stringify({ fileId }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error(error);
+    return new Response("Internal Server Error", { status: 500 });
+  }
+}

--- a/src/types/assistjur.ts
+++ b/src/types/assistjur.ts
@@ -1,5 +1,15 @@
 // Tipos específicos do pipeline AssistJur.IA
 
+export type Mode = "A" | "B" | "C";
+
+export interface Citation {
+  tribunal: string;
+  data: string;
+  numero: string;
+  ementa: string;
+  link: string;
+}
+
 export interface ProcessoRow {
   cnj: string;
   status?: string;


### PR DESCRIPTION
## Summary
- add OpenAI client and vector store helpers
- unify AssistJur generation endpoint with optional RAG
- support file uploads attaching to shared vector store

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: numerous module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bc7050408322a75d650fd4244244