### PR TITLE
feat: add CSAT rating

### DIFF
--- a/app/api/csat/route.ts
+++ b/app/api/csat/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/integrations/supabase/client'
+import { corsHeaders } from '../_shared/cors'
+import { initSentry } from '../_shared/sentry'
+
+const sentry = initSentry()
+
+const maintenance =
+  process.env.MAINTENANCE === 'true' || process.env.NEXT_PUBLIC_MAINTENANCE === 'true'
+const retryAfter = process.env.RETRY_AFTER || '3600'
+
+export async function POST(request: NextRequest) {
+  const headers = { ...corsHeaders }
+  if (maintenance) {
+    return NextResponse.json(
+      { error: 'Service under maintenance' },
+      { status: 503, headers: { ...headers, 'Retry-After': retryAfter } }
+    )
+  }
+
+  try {
+    const { sessionId, score, comment } = await request.json()
+    if (!sessionId || typeof score !== 'number') {
+      return NextResponse.json(
+        { error: 'sessionId and score are required' },
+        { status: 400, headers }
+      )
+    }
+
+    const { error } = await supabase.from('csat').insert({
+      session_id: sessionId,
+      score,
+      comment,
+    })
+
+    if (error) throw error
+
+    return NextResponse.json({ success: true }, { headers })
+  } catch (error) {
+    console.error('CSAT API Error:', error)
+    ;(await sentry)?.captureException?.(error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to save CSAT' },
+      { status: 500, headers }
+    )
+  }
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: corsHeaders })
+}
+

--- a/src/components/AssistJurPanel.tsx
+++ b/src/components/AssistJurPanel.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react"
+import { Star } from "lucide-react"
+import { useToast } from "@/components/ui/use-toast"
+
+interface AssistJurPanelProps {
+  sessionId: string
+  response: string
+  comment?: string
+}
+
+export function AssistJurPanel({ sessionId, response }: AssistJurPanelProps) {
+  const [rating, setRating] = useState(0)
+  const [submitted, setSubmitted] = useState(false)
+  const { toast } = useToast()
+
+  const handleRate = async (value: number) => {
+    if (submitted) return
+    setRating(value)
+
+    try {
+      await fetch("/api/csat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId, score: value })
+      })
+      toast({ title: "Obrigado!" })
+      setSubmitted(true)
+    } catch (error) {
+      toast({ title: "Erro ao enviar feedback", variant: "destructive" })
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>{response}</div>
+      {!submitted && (
+        <div className="flex gap-2">
+          {[1, 2, 3, 4, 5].map((n) => (
+            <button
+              key={n}
+              type="button"
+              onClick={() => handleRate(n)}
+              className="text-muted-foreground hover:text-yellow-500"
+              aria-label={`Avaliar ${n}`}
+            >
+              <Star
+                className={`h-5 w-5 ${n <= rating ? "fill-yellow-500 text-yellow-500" : ""}`}
+              />
+            </button>
+          ))}
+        </div>
+      )}
+      {submitted && (
+        <div className="flex gap-2">
+          {[1, 2, 3, 4, 5].map((n) => (
+            <Star
+              key={n}
+              className={`h-5 w-5 ${n <= rating ? "fill-yellow-500 text-yellow-500" : "text-muted-foreground"}`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -199,6 +199,30 @@ export type Database = {
         }
         Relationships: []
       }
+      csat: {
+        Row: {
+          id: string
+          session_id: string
+          score: number
+          comment: string | null
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          session_id: string
+          score: number
+          comment?: string | null
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          session_id?: string
+          score?: number
+          comment?: string | null
+          created_at?: string | null
+        }
+        Relationships: []
+      }
       data_access_logs: {
         Row: {
           access_type: string


### PR DESCRIPTION
## Summary
- add CSAT star rating component to capture user satisfaction
- create CSAT API route that stores feedback in Supabase
- define csat table types

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c6be3433dc8322b9e4228f55cd0ce9