### PR TITLE
Adjust auth flows and improve login a11y

### DIFF
--- a/src/components/auth/EmailPasswordForm.tsx
+++ b/src/components/auth/EmailPasswordForm.tsx
@@ -6,17 +6,18 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Link } from "react-router-dom";
 import { Eye, EyeOff, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { useAuth } from "@/hooks/useAuth";
-import { validatePassword, MIN_PASSWORD_LENGTH } from "@/utils/security/passwordPolicy";
+import { MIN_PASSWORD_LENGTH } from "@/utils/security/passwordPolicy";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
 import { useStatus } from "@/hooks/useStatus";
 import { ERROR_MESSAGES } from "@/utils/errorMessages";
 
 const loginSchema = z.object({
   email: z.string().email(ERROR_MESSAGES.INVALID_EMAIL),
-  password: z.string().min(6, 'Senha deve ter pelo menos 6 caracteres'),
+  password: z.string().min(6, 'Mínimo de 6 caracteres'),
   rememberMe: z.boolean().optional()
 });
 
@@ -24,7 +25,7 @@ const signupSchema = z.object({
   name: z.string().min(2, 'Nome deve ter pelo menos 2 caracteres').optional(),
   email: z.string().email(ERROR_MESSAGES.INVALID_EMAIL),
   password: z.string()
-    .min(MIN_PASSWORD_LENGTH, `Senha deve ter pelo menos ${MIN_PASSWORD_LENGTH} caracteres`),
+    .min(MIN_PASSWORD_LENGTH, `Mínimo de ${MIN_PASSWORD_LENGTH} caracteres`),
   confirmPassword: z.string(),
   acceptTerms: z.boolean().refine(val => val, 'Você deve aceitar os termos')
 }).refine(data => data.password === data.confirmPassword, {
@@ -38,13 +39,11 @@ type SignupFormData = z.infer<typeof signupSchema>;
 interface EmailPasswordFormProps {
   mode: 'signin' | 'signup';
   onModeChange: (mode: 'signin' | 'signup') => void;
-  onForgotPassword: () => void;
 }
 
 export const EmailPasswordForm = ({
   mode,
-  onModeChange,
-  onForgotPassword
+  onModeChange
 }: EmailPasswordFormProps) => {
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -123,12 +122,6 @@ export const EmailPasswordForm = ({
     setFormError(null);
 
     try {
-      const policy = await validatePassword(data.password);
-      if (!policy.valid) {
-        toast.error("Senha fraca", { description: policy.errors.join(' ') });
-        return;
-      }
-
       const { error } = await signUp(data.email, data.password, data.name);
 
       if (error) {
@@ -205,6 +198,8 @@ export const EmailPasswordForm = ({
               id="password"
               type={showPassword ? 'text' : 'password'}
               placeholder="••••••••"
+              aria-invalid={!!signupForm.formState.errors.password}
+              aria-describedby="signup-password-error"
               {...signupForm.register('password')}
               className={signupForm.formState.errors.password ? 'border-destructive pr-10' : 'pr-10'}
             />
@@ -214,16 +209,18 @@ export const EmailPasswordForm = ({
               size="sm"
               className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
               onClick={() => setShowPassword(!showPassword)}
+              aria-label={showPassword ? 'Ocultar senha' : 'Mostrar senha'}
+              aria-pressed={showPassword}
             >
               {showPassword ? (
-                <EyeOff className="h-4 w-4 text-muted-foreground" />
+                <EyeOff className="h-4 w-4 text-muted-foreground" aria-hidden="true" focusable="false" />
               ) : (
-                <Eye className="h-4 w-4 text-muted-foreground" />
+                <Eye className="h-4 w-4 text-muted-foreground" aria-hidden="true" focusable="false" />
               )}
             </Button>
           </div>
           {signupForm.formState.errors.password && (
-            <p className="text-sm text-destructive" role="alert" aria-live="polite">{signupForm.formState.errors.password.message}</p>
+            <p id="signup-password-error" className="text-sm text-destructive" role="alert" aria-live="polite">{signupForm.formState.errors.password.message}</p>
           )}
         </div>
 
@@ -235,6 +232,8 @@ export const EmailPasswordForm = ({
               id="confirmPassword"
               type={showConfirmPassword ? 'text' : 'password'}
               placeholder="••••••••"
+              aria-invalid={!!signupForm.formState.errors.confirmPassword}
+              aria-describedby="signup-confirm-password-error"
               {...signupForm.register('confirmPassword')}
               className={signupForm.formState.errors.confirmPassword ? 'border-destructive pr-10' : 'pr-10'}
             />
@@ -244,16 +243,18 @@ export const EmailPasswordForm = ({
               size="sm"
               className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
               onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+              aria-label={showConfirmPassword ? 'Ocultar senha' : 'Mostrar senha'}
+              aria-pressed={showConfirmPassword}
             >
               {showConfirmPassword ? (
-                <EyeOff className="h-4 w-4 text-muted-foreground" />
+                <EyeOff className="h-4 w-4 text-muted-foreground" aria-hidden="true" focusable="false" />
               ) : (
-                <Eye className="h-4 w-4 text-muted-foreground" />
+                <Eye className="h-4 w-4 text-muted-foreground" aria-hidden="true" focusable="false" />
               )}
             </Button>
           </div>
           {signupForm.formState.errors.confirmPassword && (
-            <p className="text-sm text-destructive" role="alert" aria-live="polite">{signupForm.formState.errors.confirmPassword.message}</p>
+            <p id="signup-confirm-password-error" className="text-sm text-destructive" role="alert" aria-live="polite">{signupForm.formState.errors.confirmPassword.message}</p>
           )}
         </div>
 
@@ -267,13 +268,13 @@ export const EmailPasswordForm = ({
           />
           <Label htmlFor="acceptTerms" className="text-sm leading-relaxed cursor-pointer">
             Li e aceito os{' '}
-            <button type="button" className="text-primary hover:underline">
+            <Link to="/termos" className="text-primary hover:underline">
               Termos de Uso
-            </button>
+            </Link>
             {' '}e a{' '}
-            <button type="button" className="text-primary hover:underline">
+            <Link to="/privacidade" className="text-primary hover:underline">
               Política de Privacidade
-            </button>
+            </Link>
           </Label>
         </div>
         {signupForm.formState.errors.acceptTerms && (
@@ -337,31 +338,37 @@ export const EmailPasswordForm = ({
       {/* Password */}
       <div className="space-y-2">
         <Label htmlFor="password">Senha</Label>
-        <div className="relative">
-          <Input
-            id="password"
-            type={showPassword ? 'text' : 'password'}
-            placeholder="••••••••"
-            {...loginForm.register('password')}
-            className={loginForm.formState.errors.password ? 'border-destructive pr-10' : 'pr-10'}
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
-            onClick={() => setShowPassword(!showPassword)}
-          >
-            {showPassword ? (
-              <EyeOff className="h-4 w-4 text-muted-foreground" />
-            ) : (
-              <Eye className="h-4 w-4 text-muted-foreground" />
-            )}
-          </Button>
+        <div className="flex flex-col sm:flex-row items-center gap-2">
+          <div className="relative flex-1">
+            <Input
+              id="password"
+              type={showPassword ? 'text' : 'password'}
+              placeholder="••••••••"
+              aria-invalid={!!loginForm.formState.errors.password}
+              aria-describedby="password-help"
+              {...loginForm.register('password')}
+              className={loginForm.formState.errors.password ? 'border-destructive pr-10' : 'pr-10'}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
+              onClick={() => setShowPassword(!showPassword)}
+              aria-label={showPassword ? 'Ocultar senha' : 'Mostrar senha'}
+              aria-pressed={showPassword}
+            >
+              {showPassword ? (
+                <EyeOff className="h-4 w-4 text-muted-foreground" aria-hidden="true" focusable="false" />
+              ) : (
+                <Eye className="h-4 w-4 text-muted-foreground" aria-hidden="true" focusable="false" />
+              )}
+            </Button>
+          </div>
+          <span id="password-help" role="alert" className="text-sm text-destructive whitespace-nowrap">
+            {loginForm.formState.errors.password?.message}
+          </span>
         </div>
-        {loginForm.formState.errors.password && (
-          <p className="text-sm text-destructive" role="alert" aria-live="polite">{loginForm.formState.errors.password.message}</p>
-        )}
       </div>
 
       {/* Remember Me */}
@@ -377,13 +384,12 @@ export const EmailPasswordForm = ({
           </Label>
         </div>
         
-        <button
-          type="button"
-          onClick={onForgotPassword}
+        <Link
+          to="/reset"
           className="text-sm text-primary hover:underline"
         >
           Esqueci minha senha
-        </button>
+        </Link>
       </div>
 
       {/* Submit Button */}

--- a/src/components/auth/MagicLinkForm.tsx
+++ b/src/components/auth/MagicLinkForm.tsx
@@ -9,6 +9,7 @@ import { ArrowLeft, Mail, Loader2, CheckCircle } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { useDebounce } from "@/hooks/useDebounce";
+import { getEnv } from "@/lib/getEnv";
 
 const magicLinkSchema = z.object({
   email: z.string().email('Formato de email inválido')
@@ -60,10 +61,11 @@ export const MagicLinkForm = ({ onBack }: MagicLinkFormProps) => {
         return;
       }
 
+      const { siteUrl } = getEnv();
       const { error } = await supabase.auth.signInWithOtp({
         email: data.email,
         options: {
-          emailRedirectTo: `${window.location.origin}/`
+          emailRedirectTo: `${siteUrl}/`
         }
       });
 

--- a/src/components/auth/OAuthButtons.tsx
+++ b/src/components/auth/OAuthButtons.tsx
@@ -4,6 +4,7 @@ import { Loader2, RefreshCw } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { AUTH_CONFIG } from "@/config/auth";
+import { getEnv } from "@/lib/getEnv";
 
 interface OAuthButtonsProps {
   disabled?: boolean;
@@ -37,9 +38,8 @@ export const OAuthButtons = ({ disabled, next }: OAuthButtonsProps) => {
       }
 
       // Determine redirect URL based on configuration
-      const redirectTo = next 
-        ? `${window.location.origin}${next}`
-        : `${window.location.origin}/dados/mapa`;
+      const { siteUrl } = getEnv();
+      const redirectTo = next ? `${siteUrl}${next}` : `${siteUrl}/dados/mapa`;
 
       const { error } = await supabase.auth.signInWithOAuth({
         provider,

--- a/src/components/auth/PasswordStrength.tsx
+++ b/src/components/auth/PasswordStrength.tsx
@@ -13,24 +13,8 @@ interface PasswordRequirement {
 
 const requirements: PasswordRequirement[] = [
   {
-    label: 'Pelo menos 8 caracteres',
-    test: (password) => password.length >= 8
-  },
-  {
-    label: 'Contém letra maiúscula',
-    test: (password) => /[A-Z]/.test(password)
-  },
-  {
-    label: 'Contém letra minúscula',
-    test: (password) => /[a-z]/.test(password)
-  },
-  {
-    label: 'Contém número',
-    test: (password) => /[0-9]/.test(password)
-  },
-  {
-    label: 'Contém símbolo especial',
-    test: (password) => /[^A-Za-z0-9]/.test(password)
+    label: 'Pelo menos 6 caracteres',
+    test: (password) => password.length >= 6
   }
 ];
 
@@ -54,25 +38,8 @@ export const PasswordStrength = ({ password }: PasswordStrengthProps) => {
     const score = metRequirements.filter(req => req.met).length;
     const percentage = (score / requirements.length) * 100;
 
-    let strength: string;
-    let color: string;
-
-    if (score <= 1) {
-      strength = 'Muito fraca';
-      color = 'bg-red-500';
-    } else if (score <= 2) {
-      strength = 'Fraca';
-      color = 'bg-orange-500';
-    } else if (score <= 3) {
-      strength = 'Regular';
-      color = 'bg-yellow-500';
-    } else if (score <= 4) {
-      strength = 'Forte';
-      color = 'bg-green-500';
-    } else {
-      strength = 'Muito forte';
-      color = 'bg-green-600';
-    }
+    const strength = score >= 1 ? 'Forte' : 'Muito fraca';
+    const color = score >= 1 ? 'bg-green-500' : 'bg-red-500';
 
     return {
       score,
@@ -102,9 +69,9 @@ export const PasswordStrength = ({ password }: PasswordStrengthProps) => {
         {analysis.requirements.map((req, index) => (
           <div key={index} className="flex items-center gap-2 text-xs">
             {req.met ? (
-              <Check className="h-3 w-3 text-green-600" />
+              <Check className="h-3 w-3 text-green-600" aria-hidden="true" focusable="false" />
             ) : (
-              <X className="h-3 w-3 text-muted-foreground" />
+              <X className="h-3 w-3 text-muted-foreground" aria-hidden="true" focusable="false" />
             )}
             <span className={req.met ? 'text-green-600' : 'text-muted-foreground'}>
               {req.label}

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -351,7 +351,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setLoading(true);
       // Redirect users back to the login page with a confirmation flag
       // so the UI can display the proper message after e-mail verification.
-      const redirectUrl = `${window.location.origin}/login?confirm=1`;
+      const { siteUrl } = getEnv();
+      const redirectUrl = `${siteUrl}/login?confirm=1`;
 
       const { data, error } = await supabase.auth.signUp({
         email,

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -27,6 +27,13 @@ const Login = () => {
   const [activeTab, setActiveTab] = useState<'signin' | 'signup'>('signin');
   const [showMagicLink, setShowMagicLink] = useState(false);
 
+  useEffect(() => {
+    if (window.location.hash.includes('access_token')) {
+      const cleanUrl = window.location.pathname + window.location.search;
+      window.history.replaceState(null, '', cleanUrl);
+    }
+  }, []);
+
   // Check for URL parameters
   const next = searchParams.get('next');
   const confirm = searchParams.get('confirm');
@@ -46,10 +53,6 @@ const Login = () => {
       }
     }
   }, [user, profile, navigate, next]);
-
-  const handleForgotPassword = () => {
-    navigate('/reset');
-  };
 
   const handleMagicLinkToggle = () => {
     setShowMagicLink(!showMagicLink);
@@ -172,7 +175,6 @@ const Login = () => {
                     <EmailPasswordForm
                       mode="signin"
                       onModeChange={handleModeChange}
-                      onForgotPassword={handleForgotPassword}
                     />
                     
                     {/* Magic Link Toggle */}
@@ -200,7 +202,6 @@ const Login = () => {
                     <EmailPasswordForm
                       mode="signup"
                       onModeChange={handleModeChange}
-                      onForgotPassword={handleForgotPassword}
                     />
                   </TabsContent>
                 </Tabs>
@@ -212,26 +213,26 @@ const Login = () => {
           <footer className="mt-8 text-center">
             <p className="text-xs text-muted-foreground">
               Dados tratados conforme{' '}
-              <button 
+              <Link
+                to="/lgpd"
                 className="text-primary hover:underline focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded-sm px-1"
-                aria-label="Abrir informações sobre LGPD"
               >
                 LGPD
-              </button>
+              </Link>
               {' • '}
-              <button 
+              <Link
+                to="/privacidade"
                 className="text-primary hover:underline focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded-sm px-1"
-                aria-label="Abrir política de privacidade"
               >
                 Política de Privacidade
-              </button>
+              </Link>
               {' • '}
-              <button 
+              <Link
+                to="/termos"
                 className="text-primary hover:underline focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded-sm px-1"
-                aria-label="Abrir termos de uso"
               >
                 Termos
-              </button>
+              </Link>
             </p>
           </footer>
         </div>

--- a/src/pages/ResetConfirm.tsx
+++ b/src/pages/ResetConfirm.tsx
@@ -13,10 +13,10 @@ import { AlertBox } from '@/components/auth/AlertBox';
 import { PasswordStrength } from '@/components/auth/PasswordStrength';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
-import { validatePassword, MIN_PASSWORD_LENGTH } from '@/utils/security/passwordPolicy';
+import { MIN_PASSWORD_LENGTH } from '@/utils/security/passwordPolicy';
 
 const confirmResetSchema = z.object({
-  password: z.string().min(MIN_PASSWORD_LENGTH, `Senha deve ter pelo menos ${MIN_PASSWORD_LENGTH} caracteres`),
+  password: z.string().min(MIN_PASSWORD_LENGTH, `Mínimo de ${MIN_PASSWORD_LENGTH} caracteres`),
   confirmPassword: z.string(),
 }).refine(data => data.password === data.confirmPassword, {
   message: "Senhas não conferem",
@@ -37,6 +37,12 @@ const ResetConfirm = () => {
   // Get token from URL fragments (Supabase auth uses hash fragments)
   const accessToken = searchParams.get('access_token');
   const refreshToken = searchParams.get('refresh_token');
+
+  useEffect(() => {
+    if (window.location.search.includes('access_token')) {
+      window.history.replaceState(null, '', window.location.pathname);
+    }
+  }, []);
 
   const form = useForm<ConfirmResetFormData>({
     resolver: zodResolver(confirmResetSchema),
@@ -81,14 +87,7 @@ const ResetConfirm = () => {
   const handleUpdatePassword = async (data: ConfirmResetFormData) => {
     setIsLoading(true);
     
-    try {
-      const policy = await validatePassword(data.password);
-      if (!policy.valid) {
-        toast.error("Senha fraca", { description: policy.errors.join(' ') });
-        return;
-      }
-
-      
+    try {      
       if (!supabase) {
         // Mock password update for development
         toast.success("Senha atualizada!", {
@@ -240,6 +239,8 @@ const ResetConfirm = () => {
                     id="password"
                     type={showPassword ? 'text' : 'password'}
                     placeholder="••••••••"
+                    aria-invalid={!!form.formState.errors.password}
+                    aria-describedby="reset-password-error"
                     {...form.register('password')}
                     className={form.formState.errors.password ? 'border-destructive pr-10' : 'pr-10'}
                   />
@@ -249,16 +250,18 @@ const ResetConfirm = () => {
                     size="sm"
                     className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
                     onClick={() => setShowPassword(!showPassword)}
+                    aria-label={showPassword ? 'Ocultar senha' : 'Mostrar senha'}
+                    aria-pressed={showPassword}
                   >
                     {showPassword ? (
-                      <EyeOff className="h-4 w-4 text-muted-foreground" />
+                      <EyeOff className="h-4 w-4 text-muted-foreground" aria-hidden="true" focusable="false" />
                     ) : (
-                      <Eye className="h-4 w-4 text-muted-foreground" />
+                      <Eye className="h-4 w-4 text-muted-foreground" aria-hidden="true" focusable="false" />
                     )}
                   </Button>
                 </div>
                 {form.formState.errors.password && (
-                  <p className="text-sm text-destructive">{form.formState.errors.password.message}</p>
+                  <p id="reset-password-error" className="text-sm text-destructive" role="alert" aria-live="polite">{form.formState.errors.password.message}</p>
                 )}
               </div>
 
@@ -275,6 +278,8 @@ const ResetConfirm = () => {
                     id="confirmPassword"
                     type={showConfirmPassword ? 'text' : 'password'}
                     placeholder="••••••••"
+                    aria-invalid={!!form.formState.errors.confirmPassword}
+                    aria-describedby="reset-confirm-password-error"
                     {...form.register('confirmPassword')}
                     className={form.formState.errors.confirmPassword ? 'border-destructive pr-10' : 'pr-10'}
                   />
@@ -284,16 +289,18 @@ const ResetConfirm = () => {
                     size="sm"
                     className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
                     onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    aria-label={showConfirmPassword ? 'Ocultar senha' : 'Mostrar senha'}
+                    aria-pressed={showConfirmPassword}
                   >
                     {showConfirmPassword ? (
-                      <EyeOff className="h-4 w-4 text-muted-foreground" />
+                      <EyeOff className="h-4 w-4 text-muted-foreground" aria-hidden="true" focusable="false" />
                     ) : (
-                      <Eye className="h-4 w-4 text-muted-foreground" />
+                      <Eye className="h-4 w-4 text-muted-foreground" aria-hidden="true" focusable="false" />
                     )}
                   </Button>
                 </div>
                 {form.formState.errors.confirmPassword && (
-                  <p className="text-sm text-destructive">{form.formState.errors.confirmPassword.message}</p>
+                  <p id="reset-confirm-password-error" className="text-sm text-destructive" role="alert" aria-live="polite">{form.formState.errors.confirmPassword.message}</p>
                 )}
               </div>
 

--- a/src/utils/security/passwordPolicy.ts
+++ b/src/utils/security/passwordPolicy.ts
@@ -1,85 +1,21 @@
-export const MIN_PASSWORD_LENGTH = 8;
-export const MIN_PASSWORD_ENTROPY = 40; // bits
+/**
+ * Simplified password policy.
+ * Product decision: reduce friction by requiring only a minimal length.
+ * Adjust MIN_PASSWORD_LENGTH here if stricter rules are needed later.
+ */
 
-const BANNED_TERMS = ['oab', 'cnj', 'cpf', 'processo'];
+export const MIN_PASSWORD_LENGTH = 6;
 
 export interface PasswordPolicyResult {
   valid: boolean;
   errors: string[];
 }
 
-export const calculateEntropy = (password: string): number => {
-  if (!password) return 0;
-  const len = password.length;
-  const frequencies: Record<string, number> = {};
-  for (const char of password) {
-    frequencies[char] = (frequencies[char] || 0) + 1;
-  }
-  let entropy = 0;
-  for (const freq of Object.values(frequencies)) {
-    const p = freq / len;
-    entropy -= p * Math.log2(p);
-  }
-  return entropy * len;
-};
-
-const sha1 = async (text: string): Promise<string> => {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(text);
-  const hashBuffer = await crypto.subtle.digest('SHA-1', data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('').toUpperCase();
-};
-
-export const isPasswordPwned = async (password: string, timeoutMs = 5000): Promise<boolean> => {
-  const hash = await sha1(password);
-  const prefix = hash.slice(0, 5);
-  const suffix = hash.slice(5);
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const res = await fetch(`https://api.pwnedpasswords.com/range/${prefix}`, {
-      method: 'GET',
-      headers: { 'Add-Padding': 'true' },
-      signal: controller.signal
-    });
-    const text = await res.text();
-    const lines = text.split('\n');
-    for (const line of lines) {
-      const [hashSuffix, count] = line.split(':');
-      if (hashSuffix === suffix) {
-        return parseInt(count) > 0;
-      }
-    }
-    return false;
-  } finally {
-    clearTimeout(timer);
-  }
-};
-
 export const validatePassword = async (password: string): Promise<PasswordPolicyResult> => {
   const errors: string[] = [];
 
   if (password.length < MIN_PASSWORD_LENGTH) {
     errors.push(`Senha deve ter pelo menos ${MIN_PASSWORD_LENGTH} caracteres`);
-  }
-
-  const entropy = calculateEntropy(password);
-  if (entropy < MIN_PASSWORD_ENTROPY) {
-    errors.push('Senha com entropia insuficiente');
-  }
-
-  if (BANNED_TERMS.some(term => password.toLowerCase().includes(term))) {
-    errors.push('Senha contém termos jurídicos comuns');
-  }
-
-  try {
-    const pwned = await isPasswordPwned(password);
-    if (pwned) {
-      errors.push('Senha comprometida em vazamentos');
-    }
-  } catch (err) {
-    console.warn('HIBP check failed', err);
   }
 
   return { valid: errors.length === 0, errors };

--- a/tests/auth-redirect.test.ts
+++ b/tests/auth-redirect.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { getDefaultRedirect } from '@/config/auth';
+
+describe('getDefaultRedirect', () => {
+  it('allows whitelisted next path', () => {
+    expect(getDefaultRedirect('ADMIN', '/admin')).toBe('/admin');
+  });
+
+  it('falls back to role default when next is invalid', () => {
+    expect(getDefaultRedirect('ANALYST', '/malicioso')).toBe('/dados/mapa');
+  });
+});
+

--- a/tests/login-password-inline.test.tsx
+++ b/tests/login-password-inline.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { EmailPasswordForm } from '@/components/auth/EmailPasswordForm';
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    signIn: vi.fn().mockResolvedValue({ error: null }),
+    signUp: vi.fn().mockResolvedValue({ error: null })
+  })
+}));
+
+describe('EmailPasswordForm password validation', () => {
+  it('shows inline password error with aria attributes', async () => {
+    render(<EmailPasswordForm mode="signin" onModeChange={() => {}} />);
+
+    const passwordInput = screen.getByLabelText('Senha');
+    await userEvent.type(passwordInput, '123');
+    const submitButton = screen.getByRole('button', { name: /Acessar área segura/i });
+    await userEvent.click(submitButton);
+
+    const error = await screen.findByText('Mínimo de 6 caracteres');
+    expect(error).toHaveAttribute('id', 'password-help');
+    expect(passwordInput).toHaveAttribute('aria-describedby', 'password-help');
+  });
+});
+


### PR DESCRIPTION
## Summary
- relax password rule to min 6 chars and show inline error
- fix auth links/redirects and remove localhost origins
- improve form a11y and add tests

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'zod', 'vite', etc.)*
- `npm test tests/login-password-inline.test.tsx tests/auth-redirect.test.ts` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ecc1f56883228f9d93e7de9ac3af