### PR TITLE
fix: display password error only when present

### DIFF
--- a/src/components/auth/EmailPasswordForm.tsx
+++ b/src/components/auth/EmailPasswordForm.tsx
@@ -365,9 +365,15 @@ export const EmailPasswordForm = ({
               )}
             </Button>
           </div>
-          <span id="password-help" role="alert" className="text-sm text-destructive whitespace-nowrap">
-            {loginForm.formState.errors.password?.message}
-          </span>
+          {loginForm.formState.errors.password && (
+            <span
+              id="password-help"
+              role="alert"
+              className="text-sm text-destructive whitespace-nowrap"
+            >
+              {loginForm.formState.errors.password.message}
+            </span>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- show login password error message only when there's an error

## Testing
- `npm test -- --run` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c7fda7d28483228ea526eb3ab9119b