### PR TITLE
fix: read reset token from URL hash

### DIFF
--- a/src/pages/ResetConfirm.tsx
+++ b/src/pages/ResetConfirm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -28,19 +28,23 @@ type ConfirmResetFormData = z.infer<typeof confirmResetSchema>;
 
 const ResetConfirm = () => {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
   const [isLoading, setIsLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [isValidToken, setIsValidToken] = useState<boolean | null>(null);
 
   // Get token from URL fragments (Supabase auth uses hash fragments)
-  const accessToken = searchParams.get('access_token');
-  const refreshToken = searchParams.get('refresh_token');
+  const params = new URLSearchParams(window.location.hash.slice(1));
+  const accessToken = params.get('access_token');
+  const refreshToken = params.get('refresh_token');
 
   useEffect(() => {
-    if (window.location.search.includes('access_token')) {
-      window.history.replaceState(null, '', window.location.pathname);
+    if (window.location.hash.includes('access_token')) {
+      window.history.replaceState(
+        null,
+        '',
+        `${window.location.pathname}${window.location.search}`
+      );
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- parse reset confirmation tokens from URL hash using `URLSearchParams`
- clear tokens by removing location hash instead of search params

## Testing
- `npm test --silent -- --run` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @testing-library/dom)*
- `npm run lint --silent` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c801522fc0832285eae93a14309c86