### PR TITLE
Normalize redirect path validation

### DIFF
--- a/src/config/auth.ts
+++ b/src/config/auth.ts
@@ -38,8 +38,20 @@ export type UserRole = 'ADMIN' | 'ANALYST' | 'VIEWER';
 
 export function getDefaultRedirect(role?: UserRole | null, next?: string | null): string {
   // Validate custom redirect first
-  if (next && AUTH_CONFIG.ALLOWED_REDIRECT_PATHS.some(path => next.startsWith(path))) {
-    return decodeURIComponent(next);
+  if (next) {
+    try {
+      const url = new URL(next, 'https://dummy');
+      const normalizedPath = decodeURIComponent(url.pathname);
+
+      if (
+        url.origin === 'https://dummy' &&
+        AUTH_CONFIG.ALLOWED_REDIRECT_PATHS.includes(normalizedPath)
+      ) {
+        return decodeURIComponent(next);
+      }
+    } catch {
+      // Ignore invalid URLs
+    }
   }
   
   // Use role-based redirect

--- a/tests/auth-redirect.test.ts
+++ b/tests/auth-redirect.test.ts
@@ -9,5 +9,9 @@ describe('getDefaultRedirect', () => {
   it('falls back to role default when next is invalid', () => {
     expect(getDefaultRedirect('ANALYST', '/malicioso')).toBe('/dados/mapa');
   });
+
+  it('normalizes path traversal attempts to default', () => {
+    expect(getDefaultRedirect('ANALYST', '/dados/mapa/../malicioso')).toBe('/dados/mapa');
+  });
 });
 


### PR DESCRIPTION
## Summary
- normalize custom redirect path using URL API and only allow configured paths
- test that path traversal attempts fall back to default redirect

## Testing
- `npm test -- tests/auth-redirect.test.ts` *(fails: vitest not found; dependency installation blocked by 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c807b5dff8832282a28a7572d49924