### PR TITLE
fix: clear reset tokens from URL hash

### DIFF
--- a/src/pages/ResetConfirm.tsx
+++ b/src/pages/ResetConfirm.tsx
@@ -40,11 +40,7 @@ const ResetConfirm = () => {
 
   useEffect(() => {
     if (window.location.hash.includes('access_token')) {
-      window.history.replaceState(
-        null,
-        '',
-        `${window.location.pathname}${window.location.search}`
-      );
+      window.location.hash = '';
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- read password reset tokens from URL hash
- clear hash fragment after tokens are processed

## Testing
- `npm test -- --run` *(fails: vitest not found)*
- `npm install --no-audit --loglevel=error` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c80d59ea448322ba4cd89aeb5b408c