### PR TITLE
chore: tighten observability metrics typing

### DIFF
--- a/src/types/observability.ts
+++ b/src/types/observability.ts
@@ -1,0 +1,50 @@
+export interface ObservabilityMetrics {
+  totalMetrics: number;
+  errors: number;
+  apiCalls: number;
+  userActions: number;
+  averageApiDuration: number | string;
+  topErrors: Array<{ error: string; count: number }>;
+}
+
+export const isObservabilityMetrics = (
+  value: unknown,
+): value is ObservabilityMetrics => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const metrics = value as Partial<Record<keyof ObservabilityMetrics, unknown>>;
+
+  const hasRequiredNumbers =
+    typeof metrics.totalMetrics === "number" &&
+    typeof metrics.errors === "number" &&
+    typeof metrics.apiCalls === "number" &&
+    typeof metrics.userActions === "number";
+
+  if (!hasRequiredNumbers) {
+    return false;
+  }
+
+  const avg = metrics.averageApiDuration;
+  if (
+    avg !== undefined &&
+    typeof avg !== "number" &&
+    typeof avg !== "string"
+  ) {
+    return false;
+  }
+
+  if (!Array.isArray(metrics.topErrors)) {
+    return false;
+  }
+
+  return metrics.topErrors.every((item) => {
+    return (
+      item &&
+      typeof item === "object" &&
+      typeof (item as { error?: unknown }).error === "string" &&
+      typeof (item as { count?: unknown }).count === "number"
+    );
+  });
+};


### PR DESCRIPTION
## Summary
- add a shared `ObservabilityMetrics` interface and guard for metrics summaries
- update the development health monitor to use the typed metrics and format API durations
- harden the health check utilities against malformed observability data and improve domain validators

## Testing
- npm run typecheck *(fails: pre-existing type errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f38c45988322b1ad9a12bcc96331