### PR TITLE
Add Vercel deployment configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,27 @@
+{
+  "version": 2,
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "installCommand": "npm install",
+  "framework": "vite",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    }
+  ],
+  "env": {
+    "NODE_VERSION": "22.x"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Vercel configuration file defining build, install, and output settings for the Vite app
- configure SPA rewrites, caching headers, and the Node 22.x runtime for deployments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3f6a176b08322bce989e678610bdd