### PR TITLE
Configure long-term caching for static assets

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,15 @@
   ],
   "headers": [
     {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
       "source": "/(.*)",
       "headers": [
         {


### PR DESCRIPTION
## Summary
- add a Vercel header rule matching /assets/(.*)
- set immutable year-long cache control for static assets
- retain existing short-lived cache rule for HTML routes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3ff95e0008322bb71a3455b942cd0