### PR TITLE
chore: ignore Vercel directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ out/
 bun.lockb
 *.tsbuildinfo
 node_modules/
+.vercel/
+.vercel/output/


### PR DESCRIPTION
## Summary
- add the `.vercel/` and `.vercel/output/` directories to `.gitignore` to avoid committing Vercel artifacts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e400d42e8c8322b7c523292eddc92f