### PR TITLE
Update gitignore for Vercel output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ bun.lockb
 *.tsbuildinfo
 node_modules/
 .vercel/
-.vercel/output/
+.vercel.output/


### PR DESCRIPTION
## Summary
- add the `.vercel.output/` directory to `.gitignore`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e40d077d988322a7bf34ef8fb84411