### PR TITLE
Fix duplicate confidence metadata in witness assistant mock data

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 
@@ -10,7 +10,10 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["src/tests/setup.ts"],
-    exclude: ["tests/integration.supabase.test.ts"],
+    exclude: [
+      ...configDefaults.exclude,
+      "tests/integration.supabase.test.ts",
+    ],
     coverage: {
       provider: "v8",
       reporter: ["lcov"],


### PR DESCRIPTION
## Summary
- add typed helper definitions in the witness assistant hook to avoid duplicate confidence keys and enrich generated metadata
- ensure fallback blocks preserve their original context metadata when updating the assistant message
- extend Vitest configuration to include the default exclusion list so dependency tests are not executed during related runs

## Testing
- `npm run build` *(fails: existing TypeScript errors in multiple modules)*
- `npx vitest related --run src/features/testemunhas/chat-engine/useAssistente.ts` *(fails: existing DemoMapaTestemunhas tour tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68e40e89165083228fa2521e3f203c87