### PR TITLE
Improve consent fallback and stabilize demo tour

### DIFF
--- a/src/components/common/FooterLegal.tsx
+++ b/src/components/common/FooterLegal.tsx
@@ -7,6 +7,11 @@ import { getEnv } from "@/lib/getEnv";
 
 export function FooterLegal() {
   const { setOpen } = useConsent();
+  const handleOpenConsent = () => {
+    if (typeof setOpen === "function") {
+      setOpen(true);
+    }
+  };
   const [buildError, setBuildError] = useState(false);
   const linkClasses =
     "text-sm text-foreground hover:text-primary underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
@@ -25,7 +30,7 @@ export function FooterLegal() {
     <footer className="bg-muted text-foreground py-4 border-t border-muted-foreground/20">
       <div className="container mx-auto px-6">
         <nav className="flex flex-wrap justify-center gap-6">
-          <button onClick={() => setOpen(true)} className={linkClasses}>
+          <button onClick={handleOpenConsent} className={linkClasses}>
             Privacidade / Gerenciar cookies
           </button>
           <Link to="/privacidade" className={linkClasses}>

--- a/src/components/navigation/AppSidebar.tsx
+++ b/src/components/navigation/AppSidebar.tsx
@@ -43,6 +43,11 @@ export function AppSidebar() {
     useSidebar();
   const location = useLocation();
   const { setOpen: setConsentOpen } = useConsent();
+  const handleOpenConsent = () => {
+    if (typeof setConsentOpen === "function") {
+      setConsentOpen(true);
+    }
+  };
   const { user, signOut, isAdmin } = useAuth();
   const { canAccess, getPermissionTooltip, userRole } =
     usePermissions();
@@ -215,7 +220,7 @@ export function AppSidebar() {
             <CommandPalette />
           </div>
           <button
-            onClick={() => setConsentOpen(true)}
+            onClick={handleOpenConsent}
             className="text-xs underline text-sidebar-foreground"
           >
             Privacidade / Gerenciar cookies

--- a/src/components/site/Footer.tsx
+++ b/src/components/site/Footer.tsx
@@ -11,6 +11,12 @@ export function Footer() {
   const navigate = useNavigate();
   const { setOpen } = useConsent();
 
+  const handleOpenConsent = () => {
+    if (typeof setOpen === "function") {
+      setOpen(true);
+    }
+  };
+
   return (
     <footer className="bg-hero-gradient text-aj-text-high py-16">
       <div className="container mx-auto px-6">
@@ -34,7 +40,7 @@ export function Footer() {
             aria-label="Links institucionais"
           >
             <button
-              onClick={() => setOpen(true)}
+              onClick={handleOpenConsent}
               className="text-sm text-aj-text-high/80 hover:text-aj-text-high transition-colors underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-aj-color-gold focus-visible:ring-offset-2"
             >
               Privacidade / Gerenciar cookies

--- a/src/pages/DemoMapaTestemunhas.tsx
+++ b/src/pages/DemoMapaTestemunhas.tsx
@@ -1,10 +1,8 @@
 import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import {
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-} from "@/components/ui/popover";
+import { Link } from "react-router-dom";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import {
   Table,
   TableHeader,
@@ -35,19 +33,8 @@ export default function DemoMapaTestemunhas() {
   const next = () => setStep((s) => Math.min(s + 1, 4));
 
   const resetTour = () => setStep(0);
-  const handleOpenChange = (currentStep: number) => (open: boolean) => {
-    // Permite fechar popovers, mas só fecha se estiver no passo atual
-    if (!open && step === currentStep) {
-      setStep(-1);
-    }
-  };
-
   const riskColor = (risco: Witness["risco"]) =>
-    risco === "Alto"
-      ? "text-red-600"
-      : risco === "Médio"
-        ? "text-yellow-600"
-        : "text-green-600";
+    risco === "Alto" ? "text-red-600" : risco === "Médio" ? "text-yellow-600" : "text-green-600";
 
   return (
     <div className="container mx-auto p-6 space-y-6">
@@ -64,18 +51,14 @@ export default function DemoMapaTestemunhas() {
           <div
             key={stepIndex}
             className={`h-2 w-8 rounded-full transition-colors ${
-              stepIndex === step
-                ? "bg-primary"
-                : stepIndex < step
-                  ? "bg-primary/60"
-                  : "bg-muted"
+              stepIndex === step ? "bg-primary" : stepIndex < step ? "bg-primary/60" : "bg-muted"
             }`}
           />
         ))}
       </div>
 
       <div className="flex gap-4">
-        <Popover open={step === 0} onOpenChange={handleOpenChange(0)}>
+        <Popover open={step === 0}>
           <PopoverTrigger asChild>
             <Button>Novo Mapa</Button>
           </PopoverTrigger>
@@ -87,7 +70,7 @@ export default function DemoMapaTestemunhas() {
           </PopoverContent>
         </Popover>
 
-        <Popover open={step === 1} onOpenChange={handleOpenChange(1)}>
+        <Popover open={step === 1}>
           <PopoverTrigger asChild>
             <Button variant="outline">Importar do CNJ (mock)</Button>
           </PopoverTrigger>
@@ -100,7 +83,7 @@ export default function DemoMapaTestemunhas() {
         </Popover>
       </div>
 
-      <Popover open={step === 2} onOpenChange={handleOpenChange(2)}>
+      <Popover open={step === 2}>
         <PopoverTrigger asChild>
           <div>
             <Table>
@@ -119,9 +102,7 @@ export default function DemoMapaTestemunhas() {
                     <TableCell>{witness.nome}</TableCell>
                     <TableCell>{witness.vinculo}</TableCell>
                     <TableCell>
-                      <span className={riskColor(witness.risco)}>
-                        {witness.risco}
-                      </span>
+                      <span className={riskColor(witness.risco)}>{witness.risco}</span>
                     </TableCell>
                     <TableCell>{witness.prova}</TableCell>
                     <TableCell>
@@ -143,7 +124,7 @@ export default function DemoMapaTestemunhas() {
         </PopoverContent>
       </Popover>
 
-      <Popover open={step === 3} onOpenChange={handleOpenChange(3)}>
+      <Popover open={step === 3}>
         <PopoverTrigger asChild>
           <div className="h-40 border rounded flex items-center justify-center text-muted-foreground">
             Mini grafo (placeholder)
@@ -157,21 +138,16 @@ export default function DemoMapaTestemunhas() {
         </PopoverContent>
       </Popover>
 
-      <Popover open={step === 4} onOpenChange={handleOpenChange(4)}>
+      <Popover open={step === 4}>
         <PopoverTrigger asChild>
           <Button>Gerar PDF (mock)</Button>
         </PopoverTrigger>
         <PopoverContent>
           <p>Gere um PDF demonstrativo.</p>
-          <Button size="sm" className="mt-2" asChild>
-            <a href="/beta">Entrar na Beta</a>
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            className="mt-2"
-            onClick={resetTour}
-          >
+          <Link to="/beta" className={cn(buttonVariants({ size: "sm" }), "mt-2")}>
+            Entrar na Beta
+          </Link>
+          <Button size="sm" variant="outline" className="mt-2" onClick={resetTour}>
             Reiniciar
           </Button>
         </PopoverContent>


### PR DESCRIPTION
## Summary
- keep `useConsent` from throwing by returning a frozen fallback during SSR/prerender and avoid auto-opening the dialog in tests
- simplify the DemoMapaTestemunhas popover flow by styling the beta CTA as a link and keeping each step controlled for predictable rendering

## Testing
- pnpm vitest related tests/demoMapaTestemunhas.test.tsx --run
- pnpm run prerender

------
https://chatgpt.com/codex/tasks/task_e_68e515cc5de8832297fd54bd69f2740c