### PR TITLE
Reorder delete callbacks before early returns

### DIFF
--- a/src/components/mapa-testemunhas/TestemunhaTable.tsx
+++ b/src/components/mapa-testemunhas/TestemunhaTable.tsx
@@ -61,14 +61,6 @@ export function TestemunhaTable({
     [setSelectedTestemunha, setIsDetailDrawerOpen],
   );
 
-  if (status !== "success") {
-    return <DataState status={status} onRetry={onRetry} />;
-  }
-
-  if (!data.length) {
-    return <DataState status="empty" onRetry={onRetry} />;
-  }
-
   const requestDelete = useCallback((t: PorTestemunha) => {
     setToDelete(t);
     setIsConfirmOpen(true);
@@ -86,6 +78,14 @@ export function TestemunhaTable({
     setIsConfirmOpen(false);
     setToDelete(null);
   }, [toDelete, remove, removeTestemunha, restoreTestemunha]);
+
+  if (status !== "success") {
+    return <DataState status={status} onRetry={onRetry} />;
+  }
+
+  if (!data.length) {
+    return <DataState status="empty" onRetry={onRetry} />;
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
- move the delete-related callbacks ahead of early returns in `TestemunhaTable`
- ensure hooks are declared before conditional exits while keeping existing dependencies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5492356cc83229bcaecc70bdf03ed